### PR TITLE
Fix skipped-property logging in ReadJsonObject

### DIFF
--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Read.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Read.cs
@@ -346,8 +346,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
                 // Fallback for unknown properties — safely skip and optionally log them
 
                 // Log the skipped property if a logger is available.
-                var skipped = reader.GetString();
-                context.Logger?.LogWarning("Skipping unknown JSON property: '{Skipped}'", skipped);
+                context.Logger?.LogWarning("Skipping unknown JSON property: '{Skipped}'", propertyName);
 
                 // Skip unknown JSON object properties.
                 reader.Skip();


### PR DESCRIPTION
## Summary
- use `propertyName` when logging skipped properties to avoid incorrect value reads

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481e6ae9c083308f9e1127f2cbb9a7