### PR TITLE
Update ApiTypeModifiers comment

### DIFF
--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeModifiers.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeModifiers.cs
@@ -12,7 +12,7 @@ namespace Evoogle.ApiFramework.Schema;
 public enum ApiTypeModifiers
 {
     #region Values    
-    /// <summary>Represents the API type has no modifiers.</summary>
+    /// <summary>Represents that the API type has no modifiers.</summary>
     None = 0,
 
     /// <summary>Represents the API instance (of API type) is required and will always be non-null.</summary>


### PR DESCRIPTION
## Summary
- fix a comment describing the `None` modifier for API types

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481e7343008330859daa9dfda99688