### PR TITLE
Add test for ignoring unknown JSON fields

### DIFF
--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/ApiTypeTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/ApiTypeTests.cs
@@ -227,6 +227,19 @@ public class ApiTypeTests(ITestOutputHelper output) : XUnitTests(output)
 
         new JsonDeserializeTest
         {
+            Name = "ApiScalarType [Boolean] With Extra Property",
+            SourceJson = @"
+            {
+                ""Kind"": ""Scalar"",
+                ""ApiName"": ""Boolean"",
+                ""ClrType"": ""System.Boolean, System.Private.CoreLib"",
+                ""Unexpected"": ""IgnoreMe""
+            }",
+            ExpectedApiType = new ApiScalarType("Boolean", typeof(bool))
+        },
+
+        new JsonDeserializeTest
+        {
             Name = "ApiScalarType [ID]",
             SourceJson =  @"
             {


### PR DESCRIPTION
## Summary
- add a JsonDeserialize case to ensure ApiScalarType handles unknown properties

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481e7878908330ba3fbabb95e0ff73