### PR TITLE
Implement ApiSchema container

### DIFF
--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiSchema.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiSchema.cs
@@ -1,0 +1,105 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Exceptions;
+using Evoogle.Extension;
+
+namespace Evoogle.ApiFramework.Schema;
+
+/// <summary>
+///     Represents a collection of <see cref="ApiType"/> instances making up a schema.
+/// </summary>
+public sealed class ApiSchema : ExtensibleBase
+{
+    #region ApiSchema Fields
+    private readonly Dictionary<string, ApiType> _apiNameLookup;
+    private readonly Dictionary<string, ApiType> _clrNameLookup;
+    private readonly Dictionary<Type, ApiType> _clrTypeLookup;
+    #endregion
+
+    #region ApiSchema Properties
+    /// <summary>Gets all API types contained within this schema.</summary>
+    public IReadOnlyCollection<ApiType> ApiTypes { get; }
+    #endregion
+
+    #region Constructors
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ApiSchema"/> class.
+    /// </summary>
+    /// <param name="apiTypes">The collection of API types to include in the schema.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="apiTypes"/> is null.</exception>
+    /// <exception cref="ApiSchemaException">Thrown if duplicate API or CLR identifiers are detected.</exception>
+    public ApiSchema(IEnumerable<ApiType> apiTypes)
+    {
+        var values = apiTypes.SafeToArray();
+
+        ValidateUnique(values.OfType<ApiNamedType>(), x => x.ApiName, nameof(ApiNamedType.ApiName));
+        ValidateUnique(values, x => x.ClrType.Name, "ClrName");
+        ValidateUnique(values, x => x.ClrType, nameof(ApiType.ClrType));
+
+        this.ApiTypes = values;
+
+        this._apiNameLookup = values
+            .OfType<ApiNamedType>()
+            .ToDictionary(x => x.ApiName, StringComparer.OrdinalIgnoreCase);
+        this._clrNameLookup = values.ToDictionary(x => x.ClrType.Name, StringComparer.OrdinalIgnoreCase);
+        this._clrTypeLookup = values.ToDictionary(x => x.ClrType);
+    }
+    #endregion
+
+    #region ApiSchema Methods
+    /// <summary>
+    ///     Attempts to retrieve an <see cref="ApiType"/> by its API name.
+    /// </summary>
+    /// <param name="apiName">The API name of the type to retrieve.</param>
+    /// <param name="apiType">When this method returns, contains the <see cref="ApiType"/> if found.</param>
+    /// <returns>True if the type is found; otherwise, false.</returns>
+    public bool TryGetByApiName(string apiName, out ApiType? apiType)
+        => this._apiNameLookup.TryGetValue(apiName, out apiType);
+
+    /// <summary>
+    ///     Attempts to retrieve an <see cref="ApiType"/> by its CLR name.
+    /// </summary>
+    /// <param name="clrName">The CLR type name to look up.</param>
+    /// <param name="apiType">When this method returns, contains the <see cref="ApiType"/> if found.</param>
+    /// <returns>True if the type is found; otherwise, false.</returns>
+    public bool TryGetByClrName(string clrName, out ApiType? apiType)
+        => this._clrNameLookup.TryGetValue(clrName, out apiType);
+
+    /// <summary>
+    ///     Attempts to retrieve an <see cref="ApiType"/> by its CLR type.
+    /// </summary>
+    /// <param name="clrType">The CLR <see cref="Type"/> to look up.</param>
+    /// <param name="apiType">When this method returns, contains the <see cref="ApiType"/> if found.</param>
+    /// <returns>True if the type is found; otherwise, false.</returns>
+    public bool TryGetByClrType(Type clrType, out ApiType? apiType)
+        => this._clrTypeLookup.TryGetValue(clrType, out apiType);
+
+    private static void ValidateUnique<T>(IEnumerable<ApiType> values, Func<ApiType, T> keySelector, string propertyName)
+    {
+        var duplicates = values
+            .GroupBy(keySelector)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        if (duplicates.Count == 0)
+            return;
+
+        var duplicatesString = string.Join(",", duplicates);
+        var message = $"Unable to create {nameof(ApiSchema)} because duplicate {propertyName} values detected: {duplicatesString}"; 
+        throw new ApiSchemaException(message);
+    }
+    #endregion
+
+    #region Object Methods
+    /// <inheritdoc/>
+    public override string ToString()
+    {
+        var count = this.ApiTypes.Count;
+        return $"{nameof(ApiSchema)} {{Count={count}}}";
+    }
+    #endregion
+}

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/ApiSchemaTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/ApiSchemaTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using FluentAssertions;
+using Evoogle.XUnit;
+using Xunit.Abstractions;
+
+namespace Evoogle.ApiFramework.Schema;
+
+public class ApiSchemaTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    #region Test Types
+    private class Person
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+    #endregion
+
+    #region Test Classes
+    private class TryGetByApiNameTest : XUnitTest
+    {
+        #region User Supplied Properties
+        public ApiSchema? Schema { get; set; }
+        public string? ApiName { get; set; }
+        public ApiType? ExpectedApiType { get; set; }
+        #endregion
+
+        #region Calculated Properties
+        private bool ActualFound { get; set; }
+        private ApiType? ActualApiType { get; set; }
+        #endregion
+
+        #region XUnitTest Methods
+        protected override void Act()
+        {
+            this.ActualFound = this.Schema!.TryGetByApiName(this.ApiName!, out var apiType);
+            this.ActualApiType = apiType;
+        }
+
+        protected override void Assert()
+        {
+            this.ActualFound.Should().BeTrue();
+            this.ActualApiType.Should().BeSameAs(this.ExpectedApiType);
+        }
+        #endregion
+    }
+
+    private class TryGetByClrLookupTest : XUnitTest
+    {
+        #region User Supplied Properties
+        public ApiSchema? Schema { get; set; }
+        public string? ClrName { get; set; }
+        public Type? ClrType { get; set; }
+        public ApiType? ExpectedApiType { get; set; }
+        #endregion
+
+        #region Calculated Properties
+        private ApiType? ByName { get; set; }
+        private ApiType? ByType { get; set; }
+        #endregion
+
+        #region XUnitTest Methods
+        protected override void Act()
+        {
+            this.Schema!.TryGetByClrName(this.ClrName!, out var byName);
+            this.Schema!.TryGetByClrType(this.ClrType!, out var byType);
+            this.ByName = byName;
+            this.ByType = byType;
+        }
+
+        protected override void Assert()
+        {
+            this.ByName.Should().BeSameAs(this.ExpectedApiType);
+            this.ByType.Should().BeSameAs(this.ExpectedApiType);
+        }
+        #endregion
+    }
+
+    private class ConstructorDuplicateTest : XUnitTest
+    {
+        #region User Supplied Properties
+        public ApiType[] ApiTypes { get; set; } = [];
+        #endregion
+
+        #region Calculated Properties
+        private Exception? ActualException { get; set; }
+        #endregion
+
+        #region XUnitTest Methods
+        protected override void Act()
+        {
+            try
+            {
+                _ = new ApiSchema(this.ApiTypes);
+            }
+            catch (Exception ex)
+            {
+                this.ActualException = ex;
+            }
+        }
+
+        protected override void Assert()
+        {
+            this.ActualException.Should().BeOfType<ApiSchemaException>();
+        }
+        #endregion
+    }
+    #endregion
+
+    #region Theory Data
+    public static TheoryDataRow<IXUnitTest>[] TryGetByApiNameTheoryData =>
+    [
+        CreateTryGetByApiNameTest(),
+    ];
+
+    private static TryGetByApiNameTest CreateTryGetByApiNameTest()
+    {
+        var booleanType = new ApiScalarType("Boolean", typeof(bool));
+        var stringType = new ApiScalarType("String", typeof(string));
+        var nameProperty = new ApiProperty("Name", stringType, ApiTypeModifiers.Required, nameof(Person.Name));
+        var personType = new ApiObjectType(nameof(Person), [nameProperty], typeof(Person));
+        var schema = new ApiSchema([booleanType, stringType, personType]);
+
+        return new TryGetByApiNameTest
+        {
+            Name = "Find Boolean by ApiName",
+            Schema = schema,
+            ApiName = "Boolean",
+            ExpectedApiType = booleanType,
+        };
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] TryGetByClrLookupTheoryData =>
+    [
+        CreateTryGetByClrLookupTest(),
+    ];
+
+    private static TryGetByClrLookupTest CreateTryGetByClrLookupTest()
+    {
+        var booleanType = new ApiScalarType("Boolean", typeof(bool));
+        var schema = new ApiSchema([booleanType]);
+
+        return new TryGetByClrLookupTest
+        {
+            Name = "Boolean by CLR name and type",
+            Schema = schema,
+            ClrName = "Boolean",
+            ClrType = typeof(bool),
+            ExpectedApiType = booleanType,
+        };
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] ConstructorDuplicateTheoryData =>
+    [
+        CreateConstructorDuplicateTest(),
+    ];
+
+    private static ConstructorDuplicateTest CreateConstructorDuplicateTest()
+    {
+        var t1 = new ApiScalarType("Boolean", typeof(bool));
+        var t2 = new ApiScalarType("Boolean", typeof(bool));
+
+        return new ConstructorDuplicateTest
+        {
+            Name = "Duplicate detection",
+            ApiTypes = [t1, t2],
+        };
+    }
+    #endregion
+
+    #region Test Methods
+    [Theory]
+    [MemberData(nameof(TryGetByApiNameTheoryData))]
+    public void TryGetByApiName(IXUnitTest test) => test.Execute(this);
+
+    [Theory]
+    [MemberData(nameof(TryGetByClrLookupTheoryData))]
+    public void TryGetByClrNameAndClrType(IXUnitTest test) => test.Execute(this);
+
+    [Theory]
+    [MemberData(nameof(ConstructorDuplicateTheoryData))]
+    public void Constructor_ThrowsWhenDuplicatesDetected(IXUnitTest test) => test.Execute(this);
+    #endregion
+}


### PR DESCRIPTION
## Summary
- add `ApiSchema` container class
- provide lookup helpers for ApiName, ClrName and ClrType
- include validation for duplicate identifiers
- migrate `ApiSchemaTests` to theory-based style

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481df50f348330ab6f867ca7d29791