### PR TITLE
Refactor JSON converters for code reuse

### DIFF
--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiSchemaJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiSchemaJsonConverter.cs
@@ -4,6 +4,7 @@
 // This file is licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -33,7 +34,69 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
     }
     #endregion
 
+        #region Context Types
+    private abstract class Context(ILogger<ApiSchemaJsonConverter>? logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames) : IJsonConverterLogger
+    {
+        public ILogger? Logger { get; } = logger;
+        ILogger? IJsonConverterLogger.Logger => Logger;
+        public JsonSerializerOptions Options { get; } = options;
+        public JsonNamingPolicy PropertyNamingPolicy { get; } = propertyNamingPolicy;
+        public PropertyNames PropertyNames { get; } = propertyNames;
+    }
+
+    private class ReadContext(ILogger<ApiSchemaJsonConverter>? logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames, ReadHandlers readHandlers)
+        : Context(logger, options, propertyNamingPolicy, propertyNames)
+    {
+        public ReadHandlers ReadHandlers { get; } = readHandlers;
+        public string? Name { get; set; }
+        public List<ApiScalarType>? ScalarTypes { get; set; }
+        public List<ApiEnumType>? EnumTypes { get; set; }
+        public List<ApiObjectType>? ObjectTypes { get; set; }
+        public Dictionary<string, object>? Extensions { get; set; }
+    }
+
+    private class WriteContext(ILogger<ApiSchemaJsonConverter>? logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames)
+        : Context(logger, options, propertyNamingPolicy, propertyNames)
+    {
+    }
+
+    private class ReadHandlers(PropertyNames propertyNames)
+    {
+        public readonly Dictionary<string, JsonConverterHelpers.JsonReadHandler<ReadContext>> PropertyHandlers = new()
+        {
+            { propertyNames.Name, HandleName },
+            { propertyNames.ApiScalarTypes, HandleApiScalarTypes },
+            { propertyNames.ApiEnumTypes, HandleApiEnumTypes },
+            { propertyNames.ApiObjectTypes, HandleApiObjectTypes },
+            { propertyNames.Extensions, HandleExtensions },
+        };
+    }
+    private static void HandleName(ref Utf8JsonReader reader, ref ReadContext context)
+    {
+        context.Name = ReadName(ref reader, context.Options, context.PropertyNames.Name);
+    }
+    private static void HandleApiScalarTypes(ref Utf8JsonReader reader, ref ReadContext context)
+    {
+        context.ScalarTypes = ReadApiScalarTypes(ref reader, context.Options, context.PropertyNames.ApiScalarTypes);
+    }
+
+    private static void HandleApiEnumTypes(ref Utf8JsonReader reader, ref ReadContext context)
+    {
+        context.EnumTypes = ReadApiEnumTypes(ref reader, context.Options, context.PropertyNames.ApiEnumTypes);
+    }
+
+    private static void HandleApiObjectTypes(ref Utf8JsonReader reader, ref ReadContext context)
+    {
+        context.ObjectTypes = ReadApiObjectTypes(ref reader, context.Options, context.PropertyNames.ApiObjectTypes);
+    }
+
+    private static void HandleExtensions(ref Utf8JsonReader reader, ref ReadContext context)
+    {
+        context.Extensions = ReadExtensions(ref reader, context.Options);
+    }
+    #endregion
     #region Read Types
+
     #endregion
 
     #region Fields
@@ -41,8 +104,6 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
 
     // Cache resolved property names per naming policy for performance and consistency
     private static readonly ConcurrentDictionary<JsonNamingPolicy, PropertyNames> PropertyNamesCache = new();
-
-    private static readonly NullJsonNamingPolicy NullJsonNamingPolicy = new();
     #endregion
 
     #region Constructors
@@ -79,66 +140,23 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
 
         var propertyNamingPolicy = GetPropertyNamingPolicy(options);
         var propertyNames = GetPropertyNames(propertyNamingPolicy);
+        var handlers = new ReadHandlers(propertyNames);
+        var context = new ReadContext(_logger, options, propertyNamingPolicy, propertyNames, handlers);
 
-        var name = default(string);
-        var scalarTypes = default(List<ApiScalarType>);
-        var enumTypes = default(List<ApiEnumType>);
-        var objectTypes = default(List<ApiObjectType>);
-        var extensions = default(Dictionary<string, object>);
+        JsonConverterHelpers.ReadJsonObject(ref reader, ref context, c => c.ReadHandlers.PropertyHandlers);
 
-        if (reader.TokenType != JsonTokenType.StartObject)
-            throw new JsonException("Expected start of an object.");
-
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-                break;
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException("Expected object property name.");
-
-            var propertyName = reader.GetString()!;
-            reader.Read();
-
-            if (propertyName == propertyNames.Name)
-            {
-                name = ReadName(ref reader, options, propertyName);
-            }
-            else if (propertyName == propertyNames.ApiScalarTypes)
-            {
-                scalarTypes = ReadApiScalarTypes(ref reader, options, propertyName);
-            }
-            else if (propertyName == propertyNames.ApiEnumTypes)
-            {
-                enumTypes = ReadApiEnumTypes(ref reader, options, propertyName);
-            }
-            else if (propertyName == propertyNames.ApiObjectTypes)
-            {
-                objectTypes = ReadApiObjectTypes(ref reader, options, propertyName);
-            }
-            else if (propertyName == propertyNames.Extensions)
-            {
-                extensions = ReadExtensions(ref reader, options);
-            }
-            else
-            {
-                _logger?.LogWarning("Skipping unknown JSON property: '{Property}'", propertyName);
-                reader.Skip();
-            }
-        }
-
-        name ??= string.Empty;
+        var name = context.Name ?? string.Empty;
 
         var apiTypes = new List<ApiType>();
-        if (scalarTypes != null) apiTypes.AddRange(scalarTypes);
-        if (enumTypes != null) apiTypes.AddRange(enumTypes);
-        if (objectTypes != null) apiTypes.AddRange(objectTypes);
+        if (context.ScalarTypes != null) apiTypes.AddRange(context.ScalarTypes);
+        if (context.EnumTypes != null) apiTypes.AddRange(context.EnumTypes);
+        if (context.ObjectTypes != null) apiTypes.AddRange(context.ObjectTypes);
 
         var schema = new ApiSchema(name, apiTypes);
 
-        if (extensions != null)
+        if (context.Extensions != null)
         {
-            foreach (var (typeName, extension) in extensions)
+            foreach (var (typeName, extension) in context.Extensions)
             {
                 var extensionType = TypeJsonConverter.GetDeserializeType(typeName);
                 schema.AttachExtension(extensionType, extension);
@@ -158,44 +176,45 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
     {
         var propertyNamingPolicy = GetPropertyNamingPolicy(options);
         var propertyNames = GetPropertyNames(propertyNamingPolicy);
+        var context = new WriteContext(_logger, options, propertyNamingPolicy, propertyNames);
 
         writer.WriteStartObject();
 
-        writer.WriteString(propertyNames.Name, apiSchema.Name);
+        writer.WriteString(context.PropertyNames.Name, apiSchema.Name);
 
-        writer.WritePropertyName(propertyNames.ApiScalarTypes);
+        writer.WritePropertyName(context.PropertyNames.ApiScalarTypes);
         writer.WriteStartArray();
         foreach (var apiType in apiSchema.ApiScalarTypes)
         {
-            JsonSerializer.Serialize<ApiType>(writer, apiType, options);
+            JsonSerializer.Serialize<ApiType>(writer, apiType, context.Options);
         }
         writer.WriteEndArray();
 
-        writer.WritePropertyName(propertyNames.ApiEnumTypes);
+        writer.WritePropertyName(context.PropertyNames.ApiEnumTypes);
         writer.WriteStartArray();
         foreach (var apiType in apiSchema.ApiEnumerationTypes)
         {
-            JsonSerializer.Serialize<ApiType>(writer, apiType, options);
+            JsonSerializer.Serialize<ApiType>(writer, apiType, context.Options);
         }
         writer.WriteEndArray();
 
-        writer.WritePropertyName(propertyNames.ApiObjectTypes);
+        writer.WritePropertyName(context.PropertyNames.ApiObjectTypes);
         writer.WriteStartArray();
         foreach (var apiType in apiSchema.ApiObjectTypes)
         {
-            JsonSerializer.Serialize<ApiType>(writer, apiType, options);
+            JsonSerializer.Serialize<ApiType>(writer, apiType, context.Options);
         }
         writer.WriteEndArray();
 
         if (apiSchema.Extensions != null)
         {
-            writer.WritePropertyName(propertyNames.Extensions);
+            writer.WritePropertyName(context.PropertyNames.Extensions);
             writer.WriteStartObject();
             foreach (var (extensionType, extension) in apiSchema.Extensions)
             {
                 var name = TypeJsonConverter.GetSerializeTypeName(extensionType);
                 writer.WritePropertyName(name);
-                JsonSerializer.Serialize(writer, extension, extensionType, options);
+                JsonSerializer.Serialize(writer, extension, extensionType, context.Options);
             }
             writer.WriteEndObject();
         }
@@ -207,8 +226,7 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
     #region Cache Implementation Methods
     private static JsonNamingPolicy GetPropertyNamingPolicy(JsonSerializerOptions options)
     {
-        var policy = options.PropertyNamingPolicy ?? NullJsonNamingPolicy;
-        return policy;
+        return JsonConverterHelpers.GetPropertyNamingPolicy(options);
     }
 
     private static PropertyNames GetPropertyNames(JsonNamingPolicy policy)
@@ -231,7 +249,7 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
         return name ?? throw new JsonException("Expected a non-null name {propertyName}.");
     }
 
-    private List<ApiScalarType> ReadApiScalarTypes(ref Utf8JsonReader reader, JsonSerializerOptions options, string propertyName)
+    private static List<ApiScalarType> ReadApiScalarTypes(ref Utf8JsonReader reader, JsonSerializerOptions options, string propertyName)
     {
         var apiTypes = JsonSerializer.Deserialize<List<ApiType>>(ref reader, options)
             ?? throw new JsonException($"Failed to deserialize {propertyName}.");
@@ -240,7 +258,7 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
         return scalarTypes;
     }
 
-    private List<ApiEnumType> ReadApiEnumTypes(ref Utf8JsonReader reader, JsonSerializerOptions options, string propertyName)
+    private static List<ApiEnumType> ReadApiEnumTypes(ref Utf8JsonReader reader, JsonSerializerOptions options, string propertyName)
     {
         var apiTypes = JsonSerializer.Deserialize<List<ApiType>>(ref reader, options)
             ?? throw new JsonException($"Failed to deserialize {propertyName}.");
@@ -249,7 +267,7 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
         return enumTypes;
     }
 
-    private List<ApiObjectType> ReadApiObjectTypes(ref Utf8JsonReader reader, JsonSerializerOptions options, string propertyName)
+    private static List<ApiObjectType> ReadApiObjectTypes(ref Utf8JsonReader reader, JsonSerializerOptions options, string propertyName)
     {
         var apiTypes = JsonSerializer.Deserialize<List<ApiType>>(ref reader, options)
             ?? throw new JsonException($"Failed to deserialize {propertyName}.");

--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Read.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Read.cs
@@ -81,12 +81,10 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
     }
 
-    private delegate void ReadHandler(ref Utf8JsonReader reader, ref ReadContext context);
-
     private class ReadHandlers(PropertyNames propertyNames)
     {
         #region ApiEnumValue Fields
-        public readonly Dictionary<string, ReadHandler> ApiEnumValuePropertyHandlers = new()
+        public readonly Dictionary<string, JsonConverterHelpers.JsonReadHandler<ReadContext>> ApiEnumValuePropertyHandlers = new()
         {
             { propertyNames.ApiEnumValue.ApiName, HandleApiEnumValueApiName },
             { propertyNames.ApiEnumValue.ClrName, HandleApiEnumValueClrName },
@@ -95,7 +93,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
 
         #region ApiProperty Fields
-        public readonly Dictionary<string, ReadHandler> ApiPropertyPropertyHandlers = new()
+        public readonly Dictionary<string, JsonConverterHelpers.JsonReadHandler<ReadContext>> ApiPropertyPropertyHandlers = new()
         {
             { propertyNames.ApiProperty.ApiName, HandleApiPropertyApiName },
             { propertyNames.ApiProperty.ApiType, HandleApiPropertyApiType },
@@ -105,7 +103,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
 
         #region ApiType Fields
-        public readonly Dictionary<string, ReadHandler> ApiTypePropertyHandlers = new()
+        public readonly Dictionary<string, JsonConverterHelpers.JsonReadHandler<ReadContext>> ApiTypePropertyHandlers = new()
         {
             // ApiType Property Handlers
             { propertyNames.ApiType.Kind, HandleApiTypeKind },
@@ -145,7 +143,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         private static void HandleApiEnumTypeApiEnumValues(ref Utf8JsonReader reader, ref ReadContext context)
         {
             context.ReadData.ApiEnumType ??= new ApiEnumTypeReadData();
-            ReadJsonArray(ref reader, ref context, (x) => HandleApiEnumTypeApiEnumValuesArrayItem);
+            JsonConverterHelpers.ReadJsonArray(ref reader, ref context, (x) => HandleApiEnumTypeApiEnumValuesArrayItem);
         }
 
         private static void HandleApiEnumTypeApiEnumValuesArrayItem(ref Utf8JsonReader reader, ref ReadContext context)
@@ -153,7 +151,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
             context.ReadData.ApiEnumType!.ApiEnumValues ??= [];
             context.ReadData.ApiEnumType!.ApiEnumValues.Add(new ApiEnumValueReadData());
 
-            ReadJsonObject(ref reader, ref context, (x) => x.ReadHandlers.ApiEnumValuePropertyHandlers);
+            JsonConverterHelpers.ReadJsonObject(ref reader, ref context, (x) => x.ReadHandlers.ApiEnumValuePropertyHandlers);
         }
         #endregion
 
@@ -192,7 +190,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         private static void HandleApiObjectTypeApiProperties(ref Utf8JsonReader reader, ref ReadContext context)
         {
             context.ReadData.ApiObjectType ??= new ApiObjectTypeReadData();
-            ReadJsonArray(ref reader, ref context, (x) => HandleApiObjectTypeApiPropertiesArrayItem);
+            JsonConverterHelpers.ReadJsonArray(ref reader, ref context, (x) => HandleApiObjectTypeApiPropertiesArrayItem);
         }
 
         private static void HandleApiObjectTypeApiPropertiesArrayItem(ref Utf8JsonReader reader, ref ReadContext context)
@@ -200,7 +198,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
             context.ReadData.ApiObjectType!.ApiProperties ??= [];
             context.ReadData.ApiObjectType!.ApiProperties.Add(new ApiPropertyReadData());
 
-            ReadJsonObject(ref reader, ref context, (x) => x.ReadHandlers.ApiPropertyPropertyHandlers);
+            JsonConverterHelpers.ReadJsonObject(ref reader, ref context, (x) => x.ReadHandlers.ApiPropertyPropertyHandlers);
         }
         #endregion
 
@@ -281,77 +279,6 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
             }
         }
         #endregion
-    }
-    #endregion
-
-    #region Read Implementation Methods
-    private static void ReadJsonArray
-    (
-        ref Utf8JsonReader reader,
-        ref ReadContext context,
-        Func<ReadContext, ReadHandler> arrayElementHandlerAccessor
-    )
-    {
-        // Validate the start of the JSON array.
-        if (reader.TokenType != JsonTokenType.StartArray)
-            throw new JsonException("Expected start of an array.");
-
-        // Iterate through the JSON array elements.
-        var handler = arrayElementHandlerAccessor(context);
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndArray)
-                break;
-
-            // Execute the JSON array element handler to read the JSON array element.
-            handler(ref reader, ref context);
-        }
-    }
-
-    private static void ReadJsonObject
-    (
-        ref Utf8JsonReader reader,
-        ref ReadContext context,
-        Func<ReadContext, Dictionary<string, ReadHandler>> propertyHandlersAccessor
-    )
-    {
-        // Validate the start of the JSON object.
-        if (reader.TokenType != JsonTokenType.StartObject)
-            throw new JsonException("Expected start of an object.");
-
-        // Read the JSON object properties.
-        var handlers = propertyHandlersAccessor(context);
-        while (reader.Read())
-        {
-            if (reader.TokenType == JsonTokenType.EndObject)
-                break;
-
-            if (reader.TokenType != JsonTokenType.PropertyName)
-                throw new JsonException("Expected object property name.");
-
-            // Read the JSON property name.
-            var propertyName = reader.GetString()!;
-
-            // Move past the JSON property name.
-            reader.Read();
-
-            // Look up the JSON property value handler based on the JSON property name.
-            if (handlers.TryGetValue(propertyName, out var handler))
-            {
-                // Execute the JSON property value handler to read the JSON property value.
-                handler(ref reader, ref context);
-            }
-            else
-            {
-                // Fallback for unknown properties — safely skip and optionally log them
-
-                // Log the skipped property if a logger is available.
-                context.Logger?.LogWarning("Skipping unknown JSON property: '{Skipped}'", propertyName);
-
-                // Skip unknown JSON object properties.
-                reader.Skip();
-            }
-        }
     }
     #endregion
 }

--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.cs
@@ -21,10 +21,11 @@ namespace Evoogle.ApiFramework.Schema;
 public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
 {
     #region Context Types
-    private abstract class Context(ILogger<ApiTypeJsonConverter>? logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames)
+    private abstract class Context(ILogger<ApiTypeJsonConverter>? logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames) : IJsonConverterLogger
     {
         #region Immutable Properties
         public ILogger<ApiTypeJsonConverter>? Logger { get; } = logger;
+        ILogger? IJsonConverterLogger.Logger => Logger;
         public JsonSerializerOptions Options { get; } = options;
         public JsonNamingPolicy PropertyNamingPolicy { get; } = propertyNamingPolicy;
         public PropertyNames PropertyNames { get; } = propertyNames;
@@ -133,8 +134,6 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
 
     // Cache read handlers per naming policy to avoid rebuilding on every call
     private static readonly ConcurrentDictionary<JsonNamingPolicy, ReadHandlers> ReadHandlersCache = new();
-
-    private static readonly NullJsonNamingPolicy NullJsonNamingPolicy = new();
     private static readonly TypeJsonConverter TypeJsonConverter = new();
     #endregion
 
@@ -177,7 +176,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
 
         context.Logger?.LogTrace("Deserializing {ApiType}", nameof(ApiType));
 
-        ReadJsonObject(ref reader, ref context, (context) => context.ReadHandlers.ApiTypePropertyHandlers);
+        JsonConverterHelpers.ReadJsonObject(ref reader, ref context, (context) => context.ReadHandlers.ApiTypePropertyHandlers);
 
         var kind = context.ReadData.ApiType?.Kind;
         var clrType = context.ReadData.ApiType?.ClrType;
@@ -213,8 +212,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
     #region Cache Implementation Methods
     private static JsonNamingPolicy GetPropertyNamingPolicy(JsonSerializerOptions options)
     {
-        var policy = options.PropertyNamingPolicy ?? NullJsonNamingPolicy;
-        return policy;
+        return JsonConverterHelpers.GetPropertyNamingPolicy(options);
     }
 
     private static PropertyNames GetPropertyNames(JsonNamingPolicy policy)

--- a/Source/Evoogle.ApiFramework.Core/Schema/JsonConverterHelpers.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/JsonConverterHelpers.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Evoogle.Json;
+
+namespace Evoogle.ApiFramework.Schema;
+
+internal static class JsonConverterHelpers
+{
+    internal delegate void JsonReadHandler<TContext>(ref Utf8JsonReader reader, ref TContext context);
+
+    internal static JsonNamingPolicy GetPropertyNamingPolicy(JsonSerializerOptions options)
+    {
+        return options.PropertyNamingPolicy ?? new NullJsonNamingPolicy();
+    }
+
+    internal static void ReadJsonArray<TContext>(
+        ref Utf8JsonReader reader,
+        ref TContext context,
+        Func<TContext, JsonReadHandler<TContext>> arrayElementHandlerAccessor)
+    {
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new JsonException("Expected start of an array.");
+
+        var handler = arrayElementHandlerAccessor(context);
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+                break;
+
+            handler(ref reader, ref context);
+        }
+    }
+
+    internal static void ReadJsonObject<TContext>(
+        ref Utf8JsonReader reader,
+        ref TContext context,
+        Func<TContext, Dictionary<string, JsonReadHandler<TContext>>> propertyHandlersAccessor)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Expected start of an object.");
+
+        var handlers = propertyHandlersAccessor(context);
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                break;
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException("Expected object property name.");
+
+            var propertyName = reader.GetString()!;
+            reader.Read();
+
+            if (handlers.TryGetValue(propertyName, out var handler))
+            {
+                handler(ref reader, ref context);
+            }
+            else if (context is IJsonConverterLogger loggerContext)
+            {
+                loggerContext.Logger?.LogWarning("Skipping unknown JSON property: '{Skipped}'", propertyName);
+                reader.Skip();
+            }
+            else
+            {
+                reader.Skip();
+            }
+        }
+    }
+}
+
+internal interface IJsonConverterLogger
+{
+    Microsoft.Extensions.Logging.ILogger? Logger { get; }
+}


### PR DESCRIPTION
## Summary
- introduce `JsonConverterHelpers` with shared JSON parsing helpers
- rework `ApiSchemaJsonConverter` to use new context model and helpers
- update `ApiTypeJsonConverter` to leverage helpers and implement logging interface
- adjust unit tests

## Testing
- `dotnet build --no-restore --nologo`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6849f665b0f88330bf260ae929b0ec6f