### PR TITLE
Reduce duplication in JSON converters

### DIFF
--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiSchemaJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiSchemaJsonConverter.cs
@@ -63,13 +63,6 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
         #endregion
     }
 
-    private readonly record struct ExtensibleBasePropertyNames
-    {
-        #region Immutable Properties
-        public required string Extensions { get; init; }
-        #endregion
-    }
-
     private readonly record struct PropertyNames
     {
         #region Immutable Properties
@@ -167,39 +160,8 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
         private static void HandleExtensibleBaseExtensions(ref Utf8JsonReader reader, ref ReadContext context)
         {
             context.ReadData.ExtensibleBase ??= new ExtensibleBaseReadData();
-            context.ReadData.ExtensibleBase.Extensions ??= [];
-
-            // Validate the start of the JSON object.
-            if (reader.TokenType != JsonTokenType.StartObject)
-                throw new JsonException("Expected start of an object.");
-
-            // Read the JSON extension object properties.
-            while (reader.Read())
-            {
-                if (reader.TokenType == JsonTokenType.EndObject)
-                    break;
-
-                if (reader.TokenType != JsonTokenType.PropertyName)
-                    throw new JsonException("Expected object property name.");
-
-                // Note: We didn't apply naming policy to extension type name as property name for round-trip compatibility.
-                // Read the JSON property name (extension type name)
-                var extensionTypeName = reader.GetString()!;
-                var extensionType = Json.TypeJsonConverter.GetDeserializeType(extensionTypeName);
-
-                context.Logger.LogTrace("Deserializing extension type: {ExtensionType}", extensionType.Name);
-
-                // Move past the JSON property name (extension type name)
-                reader.Read();
-
-                // Read the extension object
-                var options = context.Options;
-                var extension = JsonSerializer.Deserialize(ref reader, extensionType, options) ?? throw new JsonException($"Failed to deserialize {context.PropertyNames.ExtensibleBase.Extensions}.");
-
-                context.Logger.LogDebug("Deserialized  extension type: {ExtensionType}", extensionType.Name);
-
-                context.ReadData.ExtensibleBase.Extensions.Add(extensionTypeName, extension);
-            }
+            context.ReadData.ExtensibleBase.Extensions =
+                ApiJsonConverterHelpers.ReadExtensions<ApiSchemaJsonConverter>(ref reader, context.Options, context.Logger);
         }
         #endregion
     }
@@ -346,15 +308,7 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
 
     private static void AttachExtensions(in ReadContext context, ExtensibleBase extensibleBase)
     {
-        var extensions = context.ReadData.ExtensibleBase?.Extensions;
-        if (extensions != null)
-        {
-            foreach (var (extensionTypeName, extension) in extensions)
-            {
-                var extensionType = TypeJsonConverter.GetDeserializeType(extensionTypeName);
-                extensibleBase.AttachExtension(extensionType, extension);
-            }
-        }
+        ApiJsonConverterHelpers.AttachExtensions(extensibleBase, context.ReadData.ExtensibleBase?.Extensions);
     }
     #endregion
 
@@ -493,22 +447,7 @@ public class ApiSchemaJsonConverter : JsonConverter<ApiSchema>
             var extensionsPropertyName = context.PropertyNames.ExtensibleBase.Extensions;
             writer.WritePropertyName(extensionsPropertyName);
 
-            writer.WriteStartObject();
-            foreach (var (extensionType, extension) in extensions)
-            {
-                // Note: Don't apply naming policy to extension type name as property name for round-trip compatibility.
-                var extensionTypeName = TypeJsonConverter.GetSerializeTypeName(extensionType);
-
-                context.Logger.LogTrace("Serializing extension type: {ExtensionType}", extensionType.Name);
-
-                writer.WritePropertyName(extensionTypeName);
-
-                var options = context.Options;
-                JsonSerializer.Serialize(writer, extension, extensionType, options);
-
-                context.Logger.LogDebug("Serialized  extension type: {ExtensionType}", extensionType.Name);
-            }
-            writer.WriteEndObject();
+            ApiJsonConverterHelpers.WriteExtensions(writer, extensions, context.Options, context.Logger);
         }
     }
     #endregion

--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Factory.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Factory.cs
@@ -84,15 +84,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
 
     private static void AttachExtensions(in ReadContext context, ExtensibleBase extensibleBase)
     {
-        var extensions = context.ReadData.ExtensibleBase?.Extensions;
-        if (extensions != null)
-        {
-            foreach (var (extensionTypeName, extension) in extensions)
-            {
-                var extensionType = TypeJsonConverter.GetDeserializeType(extensionTypeName);
-                extensibleBase.AttachExtension(extensionType, extension);
-            }
-        }
+        ApiJsonConverterHelpers.AttachExtensions(extensibleBase, context.ReadData.ExtensibleBase?.Extensions);
     }
 
     private static ApiCollectionType CreateApiCollectionType(in ReadContext context, ApiTypeKind kind, List<ValidationResult>? validationResults)

--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Read.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Read.cs
@@ -274,39 +274,8 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         private static void HandleExtensibleBaseExtensions(ref Utf8JsonReader reader, ref ReadContext context)
         {
             context.ReadData.ExtensibleBase ??= new ExtensibleBaseReadData();
-            context.ReadData.ExtensibleBase.Extensions ??= [];
-
-            // Validate the start of the JSON object.
-            if (reader.TokenType != JsonTokenType.StartObject)
-                throw new JsonException("Expected start of an object.");
-
-            // Read the JSON extension object properties.
-            while (reader.Read())
-            {
-                if (reader.TokenType == JsonTokenType.EndObject)
-                    break;
-
-                if (reader.TokenType != JsonTokenType.PropertyName)
-                    throw new JsonException("Expected object property name.");
-
-                // Note: We didn't apply naming policy to extension type name as property name for round-trip compatibility.
-                // Read the JSON property name (extension type name)
-                var extensionTypeName = reader.GetString()!;
-                var extensionType = Json.TypeJsonConverter.GetDeserializeType(extensionTypeName);
-
-                context.Logger.LogTrace("Deserializing extension type: {ExtensionType}", extensionType.Name);
-
-                // Move past the JSON property name (extension type name)
-                reader.Read();
-
-                // Read the extension object
-                var options = context.Options;
-                var extension = JsonSerializer.Deserialize(ref reader, extensionType, options) ?? throw new JsonException($"Failed to deserialize {context.PropertyNames.ExtensibleBase.Extensions}.");
-
-                context.Logger.LogDebug("Deserialized  extension type: {ExtensionType}", extensionType.Name);
-
-                context.ReadData.ExtensibleBase.Extensions.Add(extensionTypeName, extension);
-            }
+            context.ReadData.ExtensibleBase.Extensions =
+                ApiJsonConverterHelpers.ReadExtensions<ApiTypeJsonConverter>(ref reader, context.Options, context.Logger);
         }
         #endregion
     }

--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Write.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.Write.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 
 using Evoogle.Extension;
 using Evoogle.Json;
+using Evoogle.ApiFramework.Schema.Internal;
 
 using Microsoft.Extensions.Logging;
 
@@ -405,22 +406,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
             var extensionsPropertyName = context.PropertyNames.ExtensibleBase.Extensions;
             writer.WritePropertyName(extensionsPropertyName);
 
-            writer.WriteStartObject();
-            foreach (var (extensionType, extension) in extensions)
-            {
-                // Note: Don't apply naming policy to extension type name as property name for round-trip compatibility.
-                var extensionTypeName = TypeJsonConverter.GetSerializeTypeName(extensionType);
-
-                context.Logger.LogTrace("Serializing extension type: {ExtensionType}", extensionType.Name);
-
-                writer.WritePropertyName(extensionTypeName);
-
-                var options = context.Options;
-                JsonSerializer.Serialize(writer, extension, extensionType, options);
-
-                context.Logger.LogDebug("Serialized  extension type: {ExtensionType}", extensionType.Name);
-            }
-            writer.WriteEndObject();
+            ApiJsonConverterHelpers.WriteExtensions(writer, extensions, context.Options, context.Logger);
         }
     }
     #endregion

--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiTypeJsonConverter.cs
@@ -108,13 +108,6 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
     }
 
-    private readonly record struct ExtensibleBasePropertyNames
-    {
-        #region Immutable Properties
-        public required string Extensions { get; init; }
-        #endregion
-    }
-
     private readonly record struct PropertyNames
     {
         #region Immutable Properties

--- a/Source/Evoogle.ApiFramework.Core/Schema/ExtensibleBasePropertyNames.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ExtensibleBasePropertyNames.cs
@@ -1,0 +1,6 @@
+namespace Evoogle.ApiFramework.Schema;
+
+internal readonly record struct ExtensibleBasePropertyNames
+{
+    public required string Extensions { get; init; }
+}

--- a/Source/Evoogle.ApiFramework.Core/Schema/Internal/ApiJsonConverterHelpers.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Internal/ApiJsonConverterHelpers.cs
@@ -6,6 +6,7 @@
 using System.Text.Json;
 
 using Evoogle.Json;
+using Evoogle.Extension;
 using Evoogle.Logging;
 
 using Microsoft.Extensions.Logging;
@@ -80,6 +81,83 @@ internal static class ApiJsonConverterHelpers
     public static JsonNamingPolicy GetPropertyNamingPolicy(JsonSerializerOptions options)
     {
         return options.PropertyNamingPolicy ?? new NullJsonNamingPolicy();
+    }
+    #endregion
+
+    #region Extension Methods
+    public static Dictionary<string, object> ReadExtensions<T>
+    (
+        ref Utf8JsonReader reader,
+        JsonSerializerOptions options,
+        ILogger<T> logger
+    )
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException("Expected start of an object.");
+
+        var extensions = new Dictionary<string, object>();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+                break;
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException("Expected object property name.");
+
+            var typeName = reader.GetString()!;
+            var extensionType = TypeJsonConverter.GetDeserializeType(typeName);
+
+            logger.LogTrace("Deserializing extension type: {ExtensionType}", extensionType.Name);
+
+            reader.Read();
+
+            var extension = JsonSerializer.Deserialize(ref reader, extensionType, options)
+                ?? throw new JsonException($"Failed to deserialize {typeName}.");
+
+            logger.LogDebug("Deserialized  extension type: {ExtensionType}", extensionType.Name);
+
+            extensions.Add(typeName, extension);
+        }
+
+        return extensions;
+    }
+
+    public static void WriteExtensions<T>
+    (
+        Utf8JsonWriter writer,
+        OrderedDictionary<Type, object> extensions,
+        JsonSerializerOptions options,
+        ILogger<T> logger
+    )
+    {
+        writer.WriteStartObject();
+
+        foreach (var (extensionType, extension) in extensions)
+        {
+            var typeName = TypeJsonConverter.GetSerializeTypeName(extensionType);
+
+            logger.LogTrace("Serializing extension type: {ExtensionType}", extensionType.Name);
+
+            writer.WritePropertyName(typeName);
+            JsonSerializer.Serialize(writer, extension, extensionType, options);
+
+            logger.LogDebug("Serialized  extension type: {ExtensionType}", extensionType.Name);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    public static void AttachExtensions(ExtensibleBase extensibleBase, Dictionary<string, object>? extensions)
+    {
+        if (extensions == null)
+            return;
+
+        foreach (var (typeName, extension) in extensions)
+        {
+            var extensionType = TypeJsonConverter.GetDeserializeType(typeName);
+            extensibleBase.AttachExtension(extensionType, extension);
+        }
     }
     #endregion
 }


### PR DESCRIPTION
## Summary
- add `ExtensibleBasePropertyNames` helper struct shared by converters
- centralize extension handling logic in `ApiJsonConverterHelpers`
- refactor `ApiSchemaJsonConverter` and `ApiTypeJsonConverter` to use shared helpers
- update read/write extension logic and extension attachment to use helpers

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684c970420888330bf5089a2e14c9397