### PR TITLE
Use init-only properties in XUnit tests

### DIFF
--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/ApiJsonConverterUnitTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/ApiJsonConverterUnitTests.cs
@@ -81,11 +81,11 @@ public static class ApiJsonConverterUnitTests
         #endregion
 
         #region User Supplied Properties
-        public string? Source { get; set; }
-        public T? Expected { get; set; }
-        public bool? AddTestExtension1 { get; set; } = false;
-        public bool? AddTestExtension2 { get; set; } = false;
-        public JsonSerializerOptions? JsonSerializerOptions { get; set; } = DefaultJsonSerializerOptions;
+        public string? Source { get; init; }
+        public T? Expected { get; init; }
+        public bool? AddTestExtension1 { get; init; } = false;
+        public bool? AddTestExtension2 { get; init; } = false;
+        public JsonSerializerOptions? JsonSerializerOptions { get; init; } = DefaultJsonSerializerOptions;
         #endregion
 
         #region Calculated Properties
@@ -135,10 +135,10 @@ public static class ApiJsonConverterUnitTests
         #endregion
 
         #region User Supplied Properties
-        public T? Expected { get; set; }
-        public bool? AddTestExtension1 { get; set; } = false;
-        public bool? AddTestExtension2 { get; set; } = false;
-        public JsonSerializerOptions? JsonSerializerOptions { get; set; } = DefaultJsonSerializerOptions;
+        public T? Expected { get; init; }
+        public bool? AddTestExtension1 { get; init; } = false;
+        public bool? AddTestExtension2 { get; init; } = false;
+        public JsonSerializerOptions? JsonSerializerOptions { get; init; } = DefaultJsonSerializerOptions;
         #endregion
 
         #region Calculated Properties
@@ -186,11 +186,11 @@ public static class ApiJsonConverterUnitTests
         #endregion
 
         #region User Supplied Properties
-        public T? Source { get; set; }
-        public string? Expected { get; set; }
-        public bool? AddTestExtension1 { get; set; } = false;
-        public bool? AddTestExtension2 { get; set; } = false;
-        public JsonSerializerOptions? JsonSerializerOptions { get; set; } = DefaultJsonSerializerOptions;
+        public T? Source { get; init; }
+        public string? Expected { get; init; }
+        public bool? AddTestExtension1 { get; init; } = false;
+        public bool? AddTestExtension2 { get; init; } = false;
+        public JsonSerializerOptions? JsonSerializerOptions { get; init; } = DefaultJsonSerializerOptions;
         #endregion
 
         #region Calculated Properties

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/ApiSchemaTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/ApiSchemaTests.cs
@@ -18,9 +18,9 @@ public class ApiSchemaTests(ITestOutputHelper output) : XUnitTests(output)
     private class TryGetByApiNameTest : XUnitTest
     {
         #region User Supplied Properties
-        public ApiSchema? ApiSchema { get; set; }
-        public string? ApiName { get; set; }
-        public ApiType? ExpectedApiType { get; set; }
+        public ApiSchema? ApiSchema { get; init; }
+        public string? ApiName { get; init; }
+        public ApiType? ExpectedApiType { get; init; }
         #endregion
 
         #region Calculated Properties
@@ -62,9 +62,9 @@ public class ApiSchemaTests(ITestOutputHelper output) : XUnitTests(output)
     private class TryGetByClrTypeTest : XUnitTest
     {
         #region User Supplied Properties
-        public ApiSchema? ApiSchema { get; set; }
-        public Type? ClrType { get; set; }
-        public ApiType? ExpectedApiType { get; set; }
+        public ApiSchema? ApiSchema { get; init; }
+        public Type? ClrType { get; init; }
+        public ApiType? ExpectedApiType { get; init; }
         #endregion
 
         #region Calculated Properties


### PR DESCRIPTION
## Summary
- make XUnit test property setters init-only

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686cc8bc96d0833097427566251346f4