### PR TITLE
Document API framework core components

### DIFF
--- a/Source/Evoogle.ApiFramework.Core/Exceptions/ApiSchemaValidationException.cs
+++ b/Source/Evoogle.ApiFramework.Core/Exceptions/ApiSchemaValidationException.cs
@@ -8,15 +8,26 @@ using System.ComponentModel.DataAnnotations;
 namespace Evoogle.ApiFramework.Exceptions;
 
 /// <summary>
-///     Represents errors that occur due to API schema validation failures.
+///     Represents an error that occurs when an <see cref="Evoogle.ApiFramework.Schema.ApiSchema"/> fails validation.
 /// </summary>
+/// <remarks>
+///     The exception exposes the set of <see cref="ValidationResults"/> that describe the validation failures.
+/// </remarks>
 public class ApiSchemaValidationException : ApiSchemaException
 {
     #region Properties
+    /// <summary>
+    ///     Gets the collection of validation results that caused the validation to fail.
+    /// </summary>
     public ValidationResult[] ValidationResults { get; }
     #endregion
 
     #region Constructors
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ApiSchemaValidationException"/> class with the specified validation results.
+    /// </summary>
+    /// <param name="validationResults">The set of validation results that describe the validation failures.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="validationResults"/> is <c>null</c>.</exception>
     public ApiSchemaValidationException(ValidationResult[] validationResults)
         : base()
     {
@@ -25,6 +36,12 @@ public class ApiSchemaValidationException : ApiSchemaException
         this.ValidationResults = validationResults;
     }
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ApiSchemaValidationException"/> class with a specified error message and validation results.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="validationResults">The set of validation results that describe the validation failures.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="validationResults"/> is <c>null</c>.</exception>
     public ApiSchemaValidationException(string message, ValidationResult[] validationResults)
         : base(message)
     {
@@ -33,6 +50,13 @@ public class ApiSchemaValidationException : ApiSchemaException
         this.ValidationResults = validationResults;
     }
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ApiSchemaValidationException"/> class with a specified error message, validation results, and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message that explains the reason for the exception.</param>
+    /// <param name="validationResults">The set of validation results that describe the validation failures.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="validationResults"/> is <c>null</c>.</exception>
     public ApiSchemaValidationException(string message, ValidationResult[] validationResults, Exception innerException)
         : base(message, innerException)
     {

--- a/Source/Evoogle.ApiFramework.Core/Schema/ApiProperty.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/ApiProperty.cs
@@ -21,9 +21,6 @@ namespace Evoogle.ApiFramework.Schema;
 ///         <see cref="ApiRelationship"/> instances to convey semantic meaning (e.g., parent-child, references).
 ///     </para>
 /// </remarks>
-/// <remarks>
-///     Initializes a new instance of the <see cref="ApiProperty"/> class.
-/// </remarks>
 /// <param name="apiName">The API name of the property.</param>
 /// <param name="apiTypeExpression">The API type expression of the property.</param>
 /// <param name="apiTypeModifiers">Modifiers applied to the property (e.g., Required).</param>

--- a/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ApiPropertyBuilder.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ApiPropertyBuilder.cs
@@ -9,6 +9,11 @@ using Evoogle.Reflection;
 
 namespace Evoogle.ApiFramework.Schema.Configuration;
 
+/// <summary>
+///     Builds <see cref="ApiProperty"/> definitions from CLR property metadata and optional modifiers.
+/// </summary>
+/// <param name="apiName">The API name of the property.</param>
+/// <param name="clrName">The CLR property name.</param>
 public class ApiPropertyBuilder(string apiName, string clrName) : ExtensionBuilder<ApiPropertyBuilder>
 {
     #region Fields
@@ -17,10 +22,18 @@ public class ApiPropertyBuilder(string apiName, string clrName) : ExtensionBuild
     #endregion
 
     #region Properties
+    /// <summary>
+    ///     Gets or sets a delegate that configures additional type modifiers for the property.
+    /// </summary>
     internal Action<ApiTypeModifiersBuilder>? Modifiers { get; set; }
     #endregion
 
     #region Methods
+    /// <summary>
+    ///     Builds an <see cref="ApiProperty"/> for the specified CLR object type.
+    /// </summary>
+    /// <param name="clrObjectType">The CLR type declaring the property.</param>
+    /// <returns>The constructed <see cref="ApiProperty"/> instance.</returns>
     internal ApiProperty Build(Type clrObjectType)
     {
         var apiPropertyName = _apiName;
@@ -58,6 +71,14 @@ public class ApiPropertyBuilder(string apiName, string clrName) : ExtensionBuild
         return this.CreateAndBuildExtensions(apiPropertyName, apiTypeExpression, apiTypeModifiers, clrPropertyName);
     }
 
+    /// <summary>
+    ///     Creates the <see cref="ApiProperty"/> instance and attaches any collected extensions.
+    /// </summary>
+    /// <param name="apiPropertyName">The API property name.</param>
+    /// <param name="apiTypeExpression">The property's type expression.</param>
+    /// <param name="apiTypeModifiers">Modifiers applied to the property.</param>
+    /// <param name="clrPropertyName">The CLR property name.</param>
+    /// <returns>The created <see cref="ApiProperty"/>.</returns>
     private ApiProperty CreateAndBuildExtensions(string apiPropertyName, ApiTypeExpression apiTypeExpression, ApiTypeModifiers apiTypeModifiers, string clrPropertyName)
     {
         var apiProperty = new ApiProperty(apiPropertyName, apiTypeExpression, apiTypeModifiers, clrPropertyName);

--- a/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ApiRelationshipBuilder.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ApiRelationshipBuilder.cs
@@ -5,6 +5,11 @@
 // See the LICENSE file in the project root for more information.
 namespace Evoogle.ApiFramework.Schema.Configuration;
 
+/// <summary>
+///     Builds <see cref="ApiRelationship"/> instances that describe object-to-object navigation.
+/// </summary>
+/// <param name="apiName">The API name of the relationship.</param>
+/// <param name="apiPropertyName">The API property name this relationship points to, if any.</param>
 public class ApiRelationshipBuilder(string apiName, string? apiPropertyName) : ExtensionBuilder<ApiRelationshipBuilder>
 {
     #region Fields
@@ -13,6 +18,10 @@ public class ApiRelationshipBuilder(string apiName, string? apiPropertyName) : E
     #endregion
 
     #region Methods
+    /// <summary>
+    ///     Builds the <see cref="ApiRelationship"/> configured by this builder.
+    /// </summary>
+    /// <returns>A new <see cref="ApiRelationship"/> instance.</returns>
     internal ApiRelationship Build()
     {
         var apiPropertyName = _apiPropertyName;

--- a/Source/Evoogle.ApiFramework.Core/Schema/Configuration/Dummy.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Configuration/Dummy.cs
@@ -5,41 +5,90 @@
 // See the LICENSE file in the project root for more information.
 namespace Evoogle.ApiFramework.Schema.Configuration;
 
+/// <summary>
+///     Provides sample domain models and schema configuration used for demonstration and tests.
+/// </summary>
 public static class Dummy
 {
+    /// <summary>
+    ///     Represents an email address value object.
+    /// </summary>
+    /// <param name="Email">The email string.</param>
     public record struct EmailAddress(string Email)
     {
+        /// <summary>
+        ///     Implicitly converts a string to an <see cref="EmailAddress"/>.
+        /// </summary>
+        /// <param name="address">The email address.</param>
         public static implicit operator EmailAddress(string address) => new(address);
+
+        /// <summary>
+        ///     Converts the <see cref="EmailAddress"/> to its string representation.
+        /// </summary>
+        /// <param name="emailAddress">The email address value.</param>
         public static implicit operator string(EmailAddress emailAddress) => emailAddress.Email;
     }
 
+    /// <summary>
+    ///     Sample customer entity used in configuration examples.
+    /// </summary>
     public class Customer
     {
+        /// <summary>Gets or sets the unique customer identifier.</summary>
         public Guid Id { get; set; }
+
+        /// <summary>Gets or sets the customer's display name.</summary>
         public string Name { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the customer's email address.</summary>
         public EmailAddress? Email { get; set; }
+
+        /// <summary>Gets or sets the orders associated with the customer.</summary>
         public List<Order> Orders { get; set; } = [];
     }
 
+    /// <summary>
+    ///     Sample order entity used in configuration examples.
+    /// </summary>
     public class Order
     {
+        /// <summary>Gets or sets the unique order identifier.</summary>
         public Guid Id { get; set; }
+
+        /// <summary>Gets or sets the current status of the order.</summary>
         public OrderStatus Status { get; set; }
+
+        /// <summary>Gets or sets the total monetary value of the order.</summary>
         public decimal Total { get; set; }
+
+        /// <summary>Gets or sets the identifier of the related customer.</summary>
         public Guid? CustomerId { get; set; }
+
+        /// <summary>Gets or sets the related customer.</summary>
         public Customer? Customer { get; set; }
     }
 
+    /// <summary>
+    ///     Defines the lifecycle states for an <see cref="Order"/>.
+    /// </summary>
     public enum OrderStatus
     {
+        /// <summary>The order has been created but not yet processed.</summary>
         Pending,
+        /// <summary>The order has shipped.</summary>
         Shipped,
+        /// <summary>The order has been delivered.</summary>
         Delivered,
+        /// <summary>The order was cancelled.</summary>
         Cancelled
     }
 
+    /// <summary>
+    ///     Example configuration for the <see cref="EmailAddress"/> scalar type.
+    /// </summary>
     public class EmailAddressConfiguration : IApiScalarTypeConfiguration
     {
+        /// <inheritdoc />
         public void Configure(ApiScalarTypeBuilder builder)
         {
             builder
@@ -48,8 +97,12 @@ public static class Dummy
         }
     }
 
+    /// <summary>
+    ///     Example configuration for the <see cref="OrderStatus"/> enumeration.
+    /// </summary>
     public class OrderStatusConfiguration : IApiEnumTypeConfiguration
     {
+        /// <inheritdoc />
         public void Configure(ApiEnumTypeBuilder builder)
         {
             builder
@@ -62,8 +115,12 @@ public static class Dummy
         }
     }
 
+    /// <summary>
+    ///     Example configuration for the <see cref="Order"/> object type.
+    /// </summary>
     public class OrderConfiguration : IApiObjectTypeConfiguration
     {
+        /// <inheritdoc />
         public void Configure(ApiObjectTypeBuilder builder)
         {
             builder
@@ -75,11 +132,18 @@ public static class Dummy
         }
     }
 
+    /// <summary>
+    ///     Extension metadata used to indicate whether a schema element should be visible.
+    /// </summary>
     public class VisibleMetadata
     {
+        /// <summary>Gets or sets a value indicating whether the element is visible.</summary>
         public bool Visible { get; set; }
     }
 
+    /// <summary>
+    ///     Demonstrates building an <see cref="ApiSchema"/> using the provided configuration types.
+    /// </summary>
     public static void DummyMethod()
     {
         var schema = new ApiSchemaBuilder()

--- a/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ExtensionBuilder.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ExtensionBuilder.cs
@@ -5,6 +5,11 @@
 // See the LICENSE file in the project root for more information.
 namespace Evoogle.ApiFramework.Schema.Configuration;
 
+/// <summary>
+///     Provides a base class for builders that collect extension values keyed by type.
+///     Extensions allow attaching arbitrary metadata to schema elements during configuration.
+/// </summary>
+/// <typeparam name="TBuilder">The concrete builder type.</typeparam>
 public abstract class ExtensionBuilder<TBuilder>
     where TBuilder : ExtensionBuilder<TBuilder>
 {
@@ -13,6 +18,12 @@ public abstract class ExtensionBuilder<TBuilder>
     #endregion
 
     #region Methods
+    /// <summary>
+    ///     Adds an extension value associated with the specified <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type">The type used as the extension key.</param>
+    /// <param name="value">The extension value to store.</param>
+    /// <returns>The current <typeparamref name="TBuilder"/> instance.</returns>
     public TBuilder AddExtension(Type type, object value)
     {
         ArgumentNullException.ThrowIfNull(type);
@@ -22,6 +33,9 @@ public abstract class ExtensionBuilder<TBuilder>
         return (TBuilder)this;
     }
 
+    /// <summary>
+    ///     Builds a new ordered dictionary containing the collected extensions, or <c>null</c> if none exist.
+    /// </summary>
     internal OrderedDictionary<Type, object>? BuildExtensions() =>
         _extensions.Count > 0 ? new OrderedDictionary<Type, object>(_extensions) : null;
     #endregion

--- a/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ExtensionBuilderExtensions.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ExtensionBuilderExtensions.cs
@@ -5,9 +5,21 @@
 // See the LICENSE file in the project root for more information.
 namespace Evoogle.ApiFramework.Schema.Configuration;
 
+/// <summary>
+///     Provides helper methods for adding strongly typed extensions to
+///     <see cref="ExtensionBuilder{TBuilder}"/> instances.
+/// </summary>
 public static class ExtensionBuilderExtensions
 {
     #region Methods
+    /// <summary>
+    ///     Adds an extension value keyed by its type and returns the original builder for chaining.
+    /// </summary>
+    /// <typeparam name="TBuilder">The concrete builder type.</typeparam>
+    /// <typeparam name="T">The extension value type.</typeparam>
+    /// <param name="builder">The builder to attach the extension to.</param>
+    /// <param name="value">The extension value.</param>
+    /// <returns>The same <typeparamref name="TBuilder"/> instance to support fluent calls.</returns>
     public static TBuilder AddExtension<TBuilder, T>(this ExtensionBuilder<TBuilder> builder, T value)
         where TBuilder : ExtensionBuilder<TBuilder>
         where T : notnull => builder.AddExtension(typeof(T), value);

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Factory.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Factory.cs
@@ -11,6 +11,9 @@ using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
+/// <summary>
+///     Partial implementation of <see cref="ApiTypeJsonConverter"/> containing factory helpers.
+/// </summary>
 public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
 {
     #region Factory Methods

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Read.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Read.cs
@@ -10,6 +10,9 @@ using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
+/// <summary>
+///     Partial implementation of <see cref="ApiTypeJsonConverter"/> that handles JSON reading.
+/// </summary>
 public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
 {
     #region Read Types

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Write.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Write.cs
@@ -13,6 +13,9 @@ using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
+/// <summary>
+///     Partial implementation of <see cref="ApiTypeJsonConverter"/> focused on writing JSON.
+/// </summary>
 public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
 {
     #region Write Implementation Methods


### PR DESCRIPTION
## Summary
- add XML docs for builder base classes and extension helpers
- document property and relationship builders and sample configuration types
- add summaries for JSON converter partial implementations and refine ApiProperty docs

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d1de6417083308d7a17a823b96c3d