### PR TITLE
Add unit tests for schema configuration builders

### DIFF
--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiEnumTypeBuilderTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiEnumTypeBuilderTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Schema;
+using Evoogle.ApiFramework.Schema.Configuration;
+using Evoogle.XUnit;
+using FluentAssertions;
+
+namespace Evoogle.ApiFramework.Schema.Configuration;
+
+public class ApiEnumTypeBuilderTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    public enum SampleEnum
+    {
+        First,
+        Second
+    }
+
+    private sealed class TestExtension
+    {
+        public bool Flag { get; set; }
+    }
+
+    public class BuildTest : XUnitTest
+    {
+        public bool? AddExtension { get; init; }
+
+        private ApiEnumType? ApiEnumType { get; set; }
+
+        protected override void Arrange()
+        {
+            this.WriteLine($"AddExtension: {this.AddExtension}");
+            this.WriteLine();
+        }
+
+        protected override void Act()
+        {
+            var context = new ApiSchemaBuilderContext(null);
+            var builder = new ApiEnumTypeBuilder(typeof(SampleEnum), context)
+                .WithName("SampleEnum")
+                .AddValue("first", nameof(SampleEnum.First), 0)
+                .AddValue("second", nameof(SampleEnum.Second), 1);
+            if (this.AddExtension == true)
+            {
+                builder.AddExtension(new TestExtension { Flag = true });
+            }
+            var build = typeof(ApiEnumTypeBuilder).GetMethod("Build", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            this.ApiEnumType = (ApiEnumType)build.Invoke(builder, null)!;
+            this.WriteLine($"Values: {this.ApiEnumType.ApiEnumValues.Length}");
+            this.WriteLine();
+        }
+
+        protected override void Assert()
+        {
+            this.ApiEnumType.Should().NotBeNull();
+            this.ApiEnumType!.ApiName.Should().Be("SampleEnum");
+            this.ApiEnumType.ApiEnumValues.Should().HaveCount(2);
+            if (this.AddExtension == true)
+            {
+                this.ApiEnumType.Extensions.Should().NotBeNull();
+                this.ApiEnumType.Extensions!.ContainsKey(typeof(TestExtension)).Should().BeTrue();
+            }
+        }
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] BuildTheoryData =>
+    [
+        new BuildTest
+        {
+            Name = "Builds enum type without extension",
+            AddExtension = false
+        },
+        new BuildTest
+        {
+            Name = "Builds enum type with extension",
+            AddExtension = true
+        }
+    ];
+
+    [Theory]
+    [MemberData(nameof(BuildTheoryData))]
+    public void Build(IXUnitTest test) => test.Execute(this);
+}
+

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiObjectTypeBuilderTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiObjectTypeBuilderTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Schema;
+using Evoogle.ApiFramework.Schema.Configuration;
+using Evoogle.XUnit;
+using FluentAssertions;
+
+namespace Evoogle.ApiFramework.Schema.Configuration;
+
+public class ApiObjectTypeBuilderTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    #region Test Types
+    public class Parent
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<Parent> Children { get; set; } = [];
+    }
+
+    private sealed class TestExtension
+    {
+        public bool Flag { get; set; }
+    }
+    #endregion
+
+    public class BuildTest : XUnitTest
+    {
+        private ApiObjectType? ApiObjectType { get; set; }
+
+        protected override void Act()
+        {
+            var context = new ApiSchemaBuilderContext(null);
+            var builder = new ApiObjectTypeBuilder(typeof(Parent), context)
+                .WithName("Parent")
+                .AddProperty("name", nameof(ApiObjectTypeBuilderTests.Parent.Name), m => m.Required(), p => p.AddExtension(new TestExtension { Flag = true }))
+                .AddRelationship("children", nameof(ApiObjectTypeBuilderTests.Parent.Children), r => r.AddExtension(new TestExtension { Flag = true }))
+                .AddExtension(new TestExtension { Flag = true });
+            var build = typeof(ApiObjectTypeBuilder).GetMethod("Build", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            this.ApiObjectType = (ApiObjectType)build.Invoke(builder, null)!;
+            this.WriteLine();
+        }
+
+        protected override void Assert()
+        {
+            this.ApiObjectType.Should().NotBeNull();
+            this.ApiObjectType!.ApiName.Should().Be("Parent");
+            this.ApiObjectType.ApiProperties.Should().HaveCount(1);
+            var prop = this.ApiObjectType.ApiProperties[0];
+            prop.ApiName.Should().Be("name");
+            prop.ApiTypeModifiers.Should().Be(ApiTypeModifiers.Required);
+            prop.Extensions.Should().NotBeNull();
+            prop.Extensions!.ContainsKey(typeof(TestExtension)).Should().BeTrue();
+            this.ApiObjectType.ApiRelationships.Should().HaveCount(1);
+            var rel = this.ApiObjectType.ApiRelationships[0];
+            rel.ApiName.Should().Be("children");
+            rel.ApiPropertyName.Should().Be(nameof(ApiObjectTypeBuilderTests.Parent.Children));
+            rel.Extensions.Should().NotBeNull();
+            rel.Extensions!.ContainsKey(typeof(TestExtension)).Should().BeTrue();
+            this.ApiObjectType.Extensions.Should().NotBeNull();
+            this.ApiObjectType.Extensions!.ContainsKey(typeof(TestExtension)).Should().BeTrue();
+        }
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] BuildTheoryData =>
+    [
+        new BuildTest
+        {
+            Name = "Builds object type with property, relationship and extensions"
+        }
+    ];
+
+    [Theory]
+    [MemberData(nameof(BuildTheoryData))]
+    public void Build(IXUnitTest test) => test.Execute(this);
+}
+

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiPropertyBuilderTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiPropertyBuilderTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Schema;
+using Evoogle.ApiFramework.Schema.Configuration;
+using Evoogle.XUnit;
+using FluentAssertions;
+
+namespace Evoogle.ApiFramework.Schema.Configuration;
+
+public class ApiPropertyBuilderTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    private class Sample
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class TestExtension
+    {
+        public bool Flag { get; set; }
+    }
+
+    public class BuildTest : XUnitTest
+    {
+        private ApiProperty? ApiProperty { get; set; }
+
+        protected override void Act()
+        {
+            var builder = new ApiPropertyBuilder("name", nameof(Sample.Name));
+            builder.AddExtension(new TestExtension { Flag = true });
+            var build = typeof(ApiPropertyBuilder).GetMethod("Build", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            this.ApiProperty = (ApiProperty)build.Invoke(builder, [typeof(Sample)])!;
+        }
+
+        protected override void Assert()
+        {
+            this.ApiProperty.Should().NotBeNull();
+            this.ApiProperty!.ApiName.Should().Be("name");
+            this.ApiProperty.ClrName.Should().Be(nameof(Sample.Name));
+            this.ApiProperty.ApiTypeModifiers.Should().Be(ApiTypeModifiers.Required);
+            this.ApiProperty.Extensions.Should().NotBeNull();
+            this.ApiProperty.Extensions!.ContainsKey(typeof(TestExtension)).Should().BeTrue();
+        }
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] BuildTheoryData =>
+    [
+        new BuildTest
+        {
+            Name = "Builds property for existing CLR property"
+        }
+    ];
+
+    [Theory]
+    [MemberData(nameof(BuildTheoryData))]
+    public void Build(IXUnitTest test) => test.Execute(this);
+}
+

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiRelationshipBuilderTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiRelationshipBuilderTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Schema;
+using Evoogle.ApiFramework.Schema.Configuration;
+using Evoogle.XUnit;
+using FluentAssertions;
+
+namespace Evoogle.ApiFramework.Schema.Configuration;
+
+public class ApiRelationshipBuilderTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    private sealed class TestExtension
+    {
+        public bool Flag { get; set; }
+    }
+
+    public class BuildTest : XUnitTest
+    {
+        public string? ApiName { get; init; }
+        public string? ApiPropertyName { get; init; }
+        public bool? AddExtension { get; init; }
+
+        private ApiRelationship? ApiRelationship { get; set; }
+
+        protected override void Arrange()
+        {
+            this.WriteLine($"ApiName: {this.ApiName}");
+            this.WriteLine($"ApiPropertyName: {this.ApiPropertyName}");
+            this.WriteLine($"AddExtension: {this.AddExtension}");
+            this.WriteLine();
+        }
+
+        protected override void Act()
+        {
+            var builder = new ApiRelationshipBuilder(this.ApiName!, this.ApiPropertyName);
+            if (this.AddExtension == true)
+            {
+                builder.AddExtension(new TestExtension { Flag = true });
+            }
+            var build = typeof(ApiRelationshipBuilder).GetMethod("Build", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            this.ApiRelationship = (ApiRelationship)build.Invoke(builder, null)!;
+            this.WriteLine($"Extensions? {this.ApiRelationship.Extensions is not null}");
+            this.WriteLine();
+        }
+
+        protected override void Assert()
+        {
+            this.ApiRelationship.Should().NotBeNull();
+            this.ApiRelationship!.ApiName.Should().Be(this.ApiName);
+            this.ApiRelationship.ApiPropertyName.Should().Be(this.ApiPropertyName);
+            if (this.AddExtension == true)
+            {
+                this.ApiRelationship.Extensions.Should().NotBeNull();
+                this.ApiRelationship.Extensions!.ContainsKey(typeof(TestExtension)).Should().BeTrue();
+            }
+        }
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] BuildTheoryData =>
+    [
+        new BuildTest
+        {
+            Name = "Builds relationship without extension",
+            ApiName = "rel",
+            ApiPropertyName = "prop"
+        },
+        new BuildTest
+        {
+            Name = "Builds relationship with extension",
+            ApiName = "relExt",
+            ApiPropertyName = null,
+            AddExtension = true
+        }
+    ];
+
+    [Theory]
+    [MemberData(nameof(BuildTheoryData))]
+    public void Build(IXUnitTest test) => test.Execute(this);
+}
+

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiScalarTypeBuilderTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiScalarTypeBuilderTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Schema;
+using Evoogle.ApiFramework.Schema.Configuration;
+using Evoogle.XUnit;
+using FluentAssertions;
+
+namespace Evoogle.ApiFramework.Schema.Configuration;
+
+public class ApiScalarTypeBuilderTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    private sealed class TestExtension
+    {
+        public bool Flag { get; set; }
+    }
+
+    public class BuildTest : XUnitTest
+    {
+        public bool? AddExtension { get; init; }
+
+        private ApiScalarType? ApiScalarType { get; set; }
+
+        protected override void Arrange()
+        {
+            this.WriteLine($"AddExtension: {this.AddExtension}");
+            this.WriteLine();
+        }
+
+        protected override void Act()
+        {
+            var context = new ApiSchemaBuilderContext(null);
+            var builder = new ApiScalarTypeBuilder(typeof(string), context).WithName("String");
+            if (this.AddExtension == true)
+            {
+                builder.AddExtension(new TestExtension { Flag = true });
+            }
+            var build = typeof(ApiScalarTypeBuilder).GetMethod("Build", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            this.ApiScalarType = (ApiScalarType)build.Invoke(builder, null)!;
+            this.WriteLine();
+        }
+
+        protected override void Assert()
+        {
+            this.ApiScalarType.Should().NotBeNull();
+            this.ApiScalarType!.ApiName.Should().Be("String");
+            if (this.AddExtension == true)
+            {
+                this.ApiScalarType.Extensions.Should().NotBeNull();
+                this.ApiScalarType.Extensions!.ContainsKey(typeof(TestExtension)).Should().BeTrue();
+            }
+        }
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] BuildTheoryData =>
+    [
+        new BuildTest
+        {
+            Name = "Builds scalar type without extension",
+            AddExtension = false
+        },
+        new BuildTest
+        {
+            Name = "Builds scalar type with extension",
+            AddExtension = true
+        }
+    ];
+
+    [Theory]
+    [MemberData(nameof(BuildTheoryData))]
+    public void Build(IXUnitTest test) => test.Execute(this);
+}
+

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiSchemaBuilderContextTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiSchemaBuilderContextTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Schema.Configuration;
+using Evoogle.XUnit;
+using FluentAssertions;
+
+namespace Evoogle.ApiFramework.Schema.Configuration;
+
+public class ApiSchemaBuilderContextTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    public enum BuilderKind
+    {
+        Enum,
+        Object,
+        Scalar
+    }
+
+    public class GetOrAddTest : XUnitTest
+    {
+        public BuilderKind? Kind { get; init; }
+        public Type? ClrType { get; init; }
+
+        private object? Builder1 { get; set; }
+        private object? Builder2 { get; set; }
+
+        protected override void Arrange()
+        {
+            this.WriteLine($"Kind: {this.Kind}");
+            this.WriteLine($"ClrType: {this.ClrType}");
+            this.WriteLine();
+        }
+
+        protected override void Act()
+        {
+            var context = new ApiSchemaBuilderContext(null);
+            var methodName = this.Kind switch
+            {
+                BuilderKind.Enum => "GetOrAddEnumTypeBuilder",
+                BuilderKind.Object => "GetOrAddObjectTypeBuilder",
+                BuilderKind.Scalar => "GetOrAddScalarTypeBuilder",
+                _ => throw new InvalidOperationException()
+            };
+            var method = typeof(ApiSchemaBuilderContext).GetMethod(methodName, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            this.Builder1 = method!.Invoke(context, [this.ClrType!]);
+            this.Builder2 = method.Invoke(context, [this.ClrType!]);
+        }
+
+        protected override void Assert()
+        {
+            ReferenceEquals(this.Builder1, this.Builder2).Should().BeTrue();
+        }
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] GetOrAddTheoryData =>
+    [
+        new GetOrAddTest
+        {
+            Name = "Scalar builder cached",
+            Kind = BuilderKind.Scalar,
+            ClrType = typeof(int)
+        },
+        new GetOrAddTest
+        {
+            Name = "Enum builder cached",
+            Kind = BuilderKind.Enum,
+            ClrType = typeof(ApiEnumTypeBuilderTests.SampleEnum)
+        },
+        new GetOrAddTest
+        {
+            Name = "Object builder cached",
+            Kind = BuilderKind.Object,
+            ClrType = typeof(ApiObjectTypeBuilderTests.Parent)
+        }
+    ];
+
+    [Theory]
+    [MemberData(nameof(GetOrAddTheoryData))]
+    public void GetOrAdd(IXUnitTest test) => test.Execute(this);
+}
+

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiSchemaBuilderTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiSchemaBuilderTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Schema;
+using Evoogle.ApiFramework.Schema.Configuration;
+using Evoogle.XUnit;
+using FluentAssertions;
+
+namespace Evoogle.ApiFramework.Schema.Configuration;
+
+public class ApiSchemaBuilderTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    #region Test Types
+    public record struct EmailAddress(string Value);
+
+    public enum OrderStatus
+    {
+        Pending,
+        Shipped
+    }
+
+    public class Order
+    {
+        public EmailAddress Email { get; set; }
+        public OrderStatus Status { get; set; }
+    }
+
+    public class EmailAddressConfiguration : IApiScalarTypeConfiguration
+    {
+        public void Configure(ApiScalarTypeBuilder builder) => builder.WithName("Email");
+    }
+
+    public class OrderStatusConfiguration : IApiEnumTypeConfiguration
+    {
+        public void Configure(ApiEnumTypeBuilder builder)
+        {
+            builder
+                .WithName("OrderStatus")
+                .AddValue("Pending", nameof(OrderStatus.Pending), 0)
+                .AddValue("Shipped", nameof(OrderStatus.Shipped), 1);
+        }
+    }
+
+    public class OrderConfiguration : IApiObjectTypeConfiguration
+    {
+        public void Configure(ApiObjectTypeBuilder builder)
+        {
+            builder
+                .WithName("Order")
+                .AddProperty("email", nameof(Order.Email))
+                .AddProperty("status", nameof(Order.Status));
+        }
+    }
+    #endregion
+
+    public class BuildTest : XUnitTest
+    {
+        private ApiSchema? ApiSchema { get; set; }
+
+        protected override void Act()
+        {
+            var builder = new ApiSchemaBuilder()
+                .WithName("TestSchema")
+                .WithVersion("v1")
+                .AddScalar(typeof(EmailAddress), new EmailAddressConfiguration())
+                .AddEnum(typeof(OrderStatus), new OrderStatusConfiguration())
+                .AddObject(typeof(Order), new OrderConfiguration());
+            this.ApiSchema = builder.Build();
+        }
+
+        protected override void Assert()
+        {
+            this.ApiSchema.Should().NotBeNull();
+            this.ApiSchema!.ApiName.Should().Be("TestSchema");
+            this.ApiSchema.ApiVersion.Should().Be("v1");
+            this.ApiSchema.TryGetApiScalarType(typeof(EmailAddress), out var scalar).Should().BeTrue();
+            scalar!.ApiName.Should().Be("Email");
+            this.ApiSchema.TryGetApiEnumType(typeof(OrderStatus), out var enumType).Should().BeTrue();
+            enumType!.ApiEnumValues.Should().HaveCount(2);
+            this.ApiSchema.TryGetApiObjectType(typeof(Order), out var objectType).Should().BeTrue();
+            objectType!.ApiProperties.Should().HaveCount(2);
+        }
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] BuildTheoryData =>
+    [
+        new BuildTest
+        {
+            Name = "Builds schema with configured scalar, enum and object types"
+        }
+    ];
+
+    [Theory]
+    [MemberData(nameof(BuildTheoryData))]
+    public void Build(IXUnitTest test) => test.Execute(this);
+}
+

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiTypeModifiersBuilderTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ApiTypeModifiersBuilderTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Schema.Configuration;
+using Evoogle.XUnit;
+using FluentAssertions;
+
+namespace Evoogle.ApiFramework.Schema.Configuration;
+
+public class ApiTypeModifiersBuilderTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    public class BuildTest : XUnitTest
+    {
+        public bool? UseRequired { get; init; }
+        public bool? UseOptional { get; init; }
+        public ApiTypeModifiers? Expected { get; init; }
+
+        private ApiTypeModifiers? Actual { get; set; }
+
+        protected override void Arrange()
+        {
+            this.WriteLine($"UseRequired: {this.UseRequired}");
+            this.WriteLine($"UseOptional: {this.UseOptional}");
+            this.WriteLine($"Expected: {this.Expected}");
+            this.WriteLine();
+        }
+
+        protected override void Act()
+        {
+            var builder = new ApiTypeModifiersBuilder();
+            if (this.UseRequired == true)
+            {
+                builder.Required();
+            }
+            if (this.UseOptional == true)
+            {
+                builder.Optional();
+            }
+            var build = typeof(ApiTypeModifiersBuilder).GetMethod("Build", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            this.Actual = (ApiTypeModifiers)build.Invoke(builder, null)!;
+            this.WriteLine($"Actual: {this.Actual}");
+            this.WriteLine();
+        }
+
+        protected override void Assert()
+        {
+            this.Actual.Should().Be(this.Expected);
+        }
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] BuildTheoryData =>
+    [
+        new BuildTest
+        {
+            Name = "Default is None",
+            Expected = ApiTypeModifiers.None
+        },
+        new BuildTest
+        {
+            Name = "Required sets flag",
+            UseRequired = true,
+            Expected = ApiTypeModifiers.Required
+        },
+        new BuildTest
+        {
+            Name = "Optional clears flag",
+            UseRequired = true,
+            UseOptional = true,
+            Expected = ApiTypeModifiers.None
+        }
+    ];
+
+    [Theory]
+    [MemberData(nameof(BuildTheoryData))]
+    public void Build(IXUnitTest test) => test.Execute(this);
+}
+

--- a/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ExtensionBuilderExtensionsTests.cs
+++ b/Tests/Evoogle.ApiFramework.Core.Tests/Schema/Configuration/ExtensionBuilderExtensionsTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+using Evoogle.ApiFramework.Schema;
+using Evoogle.ApiFramework.Schema.Configuration;
+using Evoogle.XUnit;
+using FluentAssertions;
+
+namespace Evoogle.ApiFramework.Schema.Configuration;
+
+public class ExtensionBuilderExtensionsTests(ITestOutputHelper output) : XUnitTests(output)
+{
+    private sealed class TestExtension
+    {
+        public int Value { get; set; }
+    }
+
+    public class GenericAddExtensionTest : XUnitTest
+    {
+        private ApiScalarType? ApiScalarType { get; set; }
+
+        protected override void Act()
+        {
+            var context = new ApiSchemaBuilderContext(null);
+            var builder = new ApiScalarTypeBuilder(typeof(int), context).WithName("Int");
+            builder.AddExtension(new TestExtension { Value = 1 });
+            var build = typeof(ApiScalarTypeBuilder).GetMethod("Build", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            this.ApiScalarType = (ApiScalarType)build.Invoke(builder, null)!;
+        }
+
+        protected override void Assert()
+        {
+            this.ApiScalarType.Should().NotBeNull();
+            this.ApiScalarType!.Extensions.Should().NotBeNull();
+            var ext = this.ApiScalarType.Extensions![typeof(TestExtension)] as TestExtension;
+            ext!.Value.Should().Be(1);
+        }
+    }
+
+    public class NonGenericAddExtensionTest : XUnitTest
+    {
+        private ApiScalarType? ApiScalarType { get; set; }
+
+        protected override void Act()
+        {
+            var context = new ApiSchemaBuilderContext(null);
+            var builder = new ApiScalarTypeBuilder(typeof(int), context).WithName("Int");
+            builder.AddExtension(typeof(TestExtension), new TestExtension { Value = 2 });
+            var build = typeof(ApiScalarTypeBuilder).GetMethod("Build", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+            this.ApiScalarType = (ApiScalarType)build.Invoke(builder, null)!;
+        }
+
+        protected override void Assert()
+        {
+            this.ApiScalarType.Should().NotBeNull();
+            this.ApiScalarType!.Extensions.Should().NotBeNull();
+            var ext = this.ApiScalarType.Extensions![typeof(TestExtension)] as TestExtension;
+            ext!.Value.Should().Be(2);
+        }
+    }
+
+    public static TheoryDataRow<IXUnitTest>[] AddExtensionTheoryData =>
+    [
+        new GenericAddExtensionTest
+        {
+            Name = "Generic AddExtension adds extension"
+        },
+        new NonGenericAddExtensionTest
+        {
+            Name = "Non generic AddExtension adds extension"
+        }
+    ];
+
+    [Theory]
+    [MemberData(nameof(AddExtensionTheoryData))]
+    public void AddExtension(IXUnitTest test) => test.Execute(this);
+}
+


### PR DESCRIPTION
## Summary
- cover ApiTypeModifiersBuilder options and extension handling
- exercise builder reflection for properties, relationships, enums, scalars and objects
- verify schema builder context caches builders and complete schema build

## Testing
- `dotnet test Tests/Evoogle.ApiFramework.Core.Tests/Evoogle.ApiFramework.Core.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_689d60a2ec0883308ef106543cace047