### PR TITLE
refactor: centralize extension handling

### DIFF
--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiEnumValueJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiEnumValueJsonConverter.cs
@@ -14,6 +14,7 @@ using Evoogle.Logging;
 using Microsoft.Extensions.Logging;
 
 using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
+using Evoogle.ApiFramework.Schema.Json.Internal;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
@@ -77,18 +78,10 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         #endregion
     }
 
-    private class ExtensibleBaseReadData
-    {
-        #region Properties
-        public Dictionary<string, object>? Extensions { get; set; }
-        #endregion
-    }
-
-    private class ReadData
+    private class ReadData : ExtensibleReadData
     {
         #region Properties
         public ApiEnumValueReadData ApiEnumValue { get; } = new();
-        public ExtensibleBaseReadData? ExtensibleBase { get; set; }
         #endregion
     }
 
@@ -107,7 +100,8 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
             { propertyNames.ApiEnumValue.ClrOrdinal, HandleApiEnumValueClrOrdinal },
 
             // ExtensibleBase Property Handlers
-            { propertyNames.ExtensibleBase.Extensions, HandleExtensibleBaseExtensions },
+            { propertyNames.ExtensibleBase.Extensions, (ref Utf8JsonReader reader, ref ReadContext context) =>
+                context.ReadData.Extensions = ReadExtensions(ref reader, context.Options, context.Logger) },
         };
         #endregion
 
@@ -128,14 +122,6 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         }
         #endregion
 
-        #region ExtensibleBase Methods
-        private static void HandleExtensibleBaseExtensions(ref Utf8JsonReader reader, ref ReadContext context)
-        {
-            context.ReadData.ExtensibleBase ??= new ExtensibleBaseReadData();
-
-            context.ReadData.ExtensibleBase.Extensions = ReadExtensions(ref reader, context.Options, context.Logger);
-        }
-        #endregion
     }
     #endregion
 
@@ -226,7 +212,7 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         var apiEnumValueReadData = context.ReadData.ApiEnumValue;
         var apiEnumValue = CreateApiEnumValue(apiEnumValueReadData);
 
-        var extensions = context.ReadData.ExtensibleBase?.Extensions;
+        var extensions = context.ReadData.Extensions;
         AttachExtensions(apiEnumValue, extensions);
 
         return apiEnumValue;
@@ -251,7 +237,7 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         WriteApiEnumValueClrName(writer, apiEnumValue, context);
         WriteApiEnumValueClrOrdinal(writer, apiEnumValue, context);
 
-        WriteExtensibleBaseExtensions(writer, apiEnumValue, context);
+        WriteExtensibleBaseExtensions(writer, apiEnumValue, context.PropertyNames.ExtensibleBase.Extensions, context.Options, context.Logger);
 
         writer.WriteEndObject();
     }
@@ -283,16 +269,5 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         writer.TryWritePropertyAsNumber(propertyName, value, options);
     }
 
-    private static void WriteExtensibleBaseExtensions(Utf8JsonWriter writer, ExtensibleBase extensibleBase, WriteContext context)
-    {
-        var extensions = extensibleBase.Extensions;
-        if (extensions != null)
-        {
-            var extensionsPropertyName = context.PropertyNames.ExtensibleBase.Extensions;
-            writer.WritePropertyName(extensionsPropertyName);
-
-            WriteExtensions(writer, extensions, context.Options, context.Logger);
-        }
-    }
     #endregion
 }

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiPropertyJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiPropertyJsonConverter.cs
@@ -14,6 +14,7 @@ using Evoogle.Logging;
 using Microsoft.Extensions.Logging;
 
 using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
+using Evoogle.ApiFramework.Schema.Json.Internal;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
@@ -79,18 +80,10 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         #endregion
     }
 
-    private class ExtensibleBaseReadData
-    {
-        #region Properties
-        public Dictionary<string, object>? Extensions { get; set; }
-        #endregion
-    }
-
-    private class ReadData
+    private class ReadData : ExtensibleReadData
     {
         #region Properties
         public ApiPropertyReadData ApiProperty { get; } = new();
-        public ExtensibleBaseReadData? ExtensibleBase { get; set; }
         #endregion
     }
 
@@ -110,7 +103,8 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
             { propertyNames.ApiProperty.ClrName, HandleApiPropertyClrName },
 
             // ExtensibleBase Property Handlers
-            { propertyNames.ExtensibleBase.Extensions, HandleExtensibleBaseExtensions },
+            { propertyNames.ExtensibleBase.Extensions, (ref Utf8JsonReader reader, ref ReadContext context) =>
+                context.ReadData.Extensions = ReadExtensions(ref reader, context.Options, context.Logger) },
         };
         #endregion
 
@@ -137,14 +131,6 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         }
         #endregion
 
-        #region ExtensibleBase Methods
-        private static void HandleExtensibleBaseExtensions(ref Utf8JsonReader reader, ref ReadContext context)
-        {
-            context.ReadData.ExtensibleBase ??= new ExtensibleBaseReadData();
-
-            context.ReadData.ExtensibleBase.Extensions = ReadExtensions(ref reader, context.Options, context.Logger);
-        }
-        #endregion
     }
     #endregion
 
@@ -236,7 +222,7 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         var apiPropertyReadData = context.ReadData.ApiProperty;
         var apiProperty = CreateApiProperty(apiPropertyReadData);
 
-        var extensions = context.ReadData.ExtensibleBase?.Extensions;
+        var extensions = context.ReadData.Extensions;
         AttachExtensions(apiProperty, extensions);
 
         return apiProperty;
@@ -264,7 +250,7 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         WriteApiPropertyApiTypeModifiers(writer, apiProperty, context);
         WriteApiPropertyClrName(writer, apiProperty, context);
 
-        WriteExtensibleBaseExtensions(writer, apiProperty, context);
+        WriteExtensibleBaseExtensions(writer, apiProperty, context.PropertyNames.ExtensibleBase.Extensions, context.Options, context.Logger);
         
         writer.WriteEndObject();
     }
@@ -305,16 +291,5 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         writer.TryWritePropertyAsString(propertyName, value, options);
     }
 
-    private static void WriteExtensibleBaseExtensions(Utf8JsonWriter writer, ExtensibleBase extensibleBase, WriteContext context)
-    {
-        var extensions = extensibleBase.Extensions;
-        if (extensions != null)
-        {
-            var extensionsPropertyName = context.PropertyNames.ExtensibleBase.Extensions;
-            writer.WritePropertyName(extensionsPropertyName);
-
-            WriteExtensions(writer, extensions, context.Options, context.Logger);
-        }
-    }
     #endregion
 }

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiRelationshipJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiRelationshipJsonConverter.cs
@@ -14,6 +14,7 @@ using Evoogle.Logging;
 using Microsoft.Extensions.Logging;
 
 using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
+using Evoogle.ApiFramework.Schema.Json.Internal;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
@@ -75,18 +76,10 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         #endregion
     }
 
-    private class ExtensibleBaseReadData
-    {
-        #region Properties
-        public Dictionary<string, object>? Extensions { get; set; }
-        #endregion
-    }
-
-    private class ReadData
+    private class ReadData : ExtensibleReadData
     {
         #region Properties
         public ApiRelationshipReadData ApiRelationship { get; } = new();
-        public ExtensibleBaseReadData? ExtensibleBase { get; set; }
         #endregion
     }
 
@@ -104,7 +97,8 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
             { propertyNames.ApiRelationship.ApiPropertyName, HandleApiRelationshipApiPropertyName },
 
             // ExtensibleBase Property Handlers
-            { propertyNames.ExtensibleBase.Extensions, HandleExtensibleBaseExtensions },
+            { propertyNames.ExtensibleBase.Extensions, (ref Utf8JsonReader reader, ref ReadContext context) =>
+                context.ReadData.Extensions = ReadExtensions(ref reader, context.Options, context.Logger) },
         };
         #endregion
 
@@ -120,14 +114,6 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         }
         #endregion
 
-        #region ExtensibleBase Methods
-        private static void HandleExtensibleBaseExtensions(ref Utf8JsonReader reader, ref ReadContext context)
-        {
-            context.ReadData.ExtensibleBase ??= new ExtensibleBaseReadData();
-
-            context.ReadData.ExtensibleBase.Extensions = ReadExtensions(ref reader, context.Options, context.Logger);
-        }
-        #endregion
     }
     #endregion
 
@@ -217,7 +203,7 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         var apiRelationshipReadData = context.ReadData.ApiRelationship;
         var apiRelationship = CreateApiRelationship(apiRelationshipReadData);
 
-        var extensions = context.ReadData.ExtensibleBase?.Extensions;
+        var extensions = context.ReadData.Extensions;
         AttachExtensions(apiRelationship, extensions);
 
         return apiRelationship;
@@ -240,7 +226,7 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         WriteApiRelationshipApiName(writer, apiRelationship, context);
         WriteApiRelationshipApiPropertyName(writer, apiRelationship, context);
 
-        WriteExtensibleBaseExtensions(writer, apiRelationship, context);
+        WriteExtensibleBaseExtensions(writer, apiRelationship, context.PropertyNames.ExtensibleBase.Extensions, context.Options, context.Logger);
 
         writer.WriteEndObject();
     }
@@ -270,16 +256,5 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         writer.TryWritePropertyAsString(propertyName, apiPropertyName, options);
     }
 
-    private static void WriteExtensibleBaseExtensions(Utf8JsonWriter writer, ExtensibleBase extensibleBase, WriteContext context)
-    {
-        var extensions = extensibleBase.Extensions;
-        if (extensions != null)
-        {
-            var extensionsPropertyName = context.PropertyNames.ExtensibleBase.Extensions;
-            writer.WritePropertyName(extensionsPropertyName);
-
-            WriteExtensions(writer, extensions, context.Options, context.Logger);
-        }
-    }
     #endregion
 }

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiSchemaJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiSchemaJsonConverter.cs
@@ -14,6 +14,7 @@ using Evoogle.Logging;
 using Microsoft.Extensions.Logging;
 
 using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
+using Evoogle.ApiFramework.Schema.Json.Internal;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
@@ -100,18 +101,10 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
         #endregion
     }
 
-    private class ExtensibleBaseReadData
-    {
-        #region Properties
-        public Dictionary<string, object>? Extensions { get; set; }
-        #endregion
-    }
-
-    private class ReadData
+    private class ReadData : ExtensibleReadData
     {
         #region Properties
         public ApiSchemaReadData? ApiSchema { get; set; }
-        public ExtensibleBaseReadData? ExtensibleBase { get; set; }
         #endregion
     }
 
@@ -128,7 +121,8 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
             { propertyNames.ApiSchema.ApiObjectTypes, HandleApiObjectTypes },
 
             // ExtensibleBase Property Handlers
-            { propertyNames.ExtensibleBase.Extensions, HandleExtensibleBaseExtensions },
+            { propertyNames.ExtensibleBase.Extensions, (ref Utf8JsonReader reader, ref ReadContext context) =>
+                context.ReadData.Extensions = ReadExtensions(ref reader, context.Options, context.Logger) },
         };
         #endregion
 
@@ -181,13 +175,6 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
         }
         #endregion
 
-        #region ExtensibleBase Methods
-        private static void HandleExtensibleBaseExtensions(ref Utf8JsonReader reader, ref ReadContext context)
-        {
-            context.ReadData.ExtensibleBase ??= new ExtensibleBaseReadData();
-            context.ReadData.ExtensibleBase.Extensions = ReadExtensions(ref reader, context.Options, context.Logger);
-        }
-        #endregion
     }
     #endregion
 
@@ -309,7 +296,7 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
         };
 
         // Attach the extensions if present.
-        var extensions = context.ReadData.ExtensibleBase?.Extensions;
+        var extensions = context.ReadData.Extensions;
         AttachExtensions(apiSchema, extensions);
 
         // Initialize the ApiSchema instance.
@@ -345,7 +332,7 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
 
     private static void WriteApiSchemaEpilog(Utf8JsonWriter writer, ApiSchema apiSchema, WriteContext context)
     {
-        WriteExtensibleBaseExtensions(writer, apiSchema, context);
+        WriteExtensibleBaseExtensions(writer, apiSchema, context.PropertyNames.ExtensibleBase.Extensions, context.Options, context.Logger);
 
         writer.WriteEndObject();
     }
@@ -377,16 +364,5 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
     }
 
     // ExtensibleBase Methods
-    private static void WriteExtensibleBaseExtensions(Utf8JsonWriter writer, ExtensibleBase extensibleBase, WriteContext context)
-    {
-        var extensions = extensibleBase.Extensions;
-        if (extensions != null)
-        {
-            var extensionsPropertyName = context.PropertyNames.ExtensibleBase.Extensions;
-            writer.WritePropertyName(extensionsPropertyName);
-
-            WriteExtensions(writer, extensions, context.Options, context.Logger);
-        }
-    }
     #endregion
 }

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Factory.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Factory.cs
@@ -52,7 +52,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
 
         apiType ??= new ApiUnknownType();
 
-        var extensions = context.ReadData.ExtensibleBase?.Extensions;
+        var extensions = context.ReadData.Extensions;
         AttachExtensions(apiType, extensions);
 
         return apiType;

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Read.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Read.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
+using Evoogle.ApiFramework.Schema.Json.Internal;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
@@ -54,14 +55,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
     }
 
-    private class ExtensibleBaseReadData
-    {
-        #region Properties
-        public Dictionary<string, object>? Extensions { get; set; }
-        #endregion
-    }
-
-    private class ReadData
+    private class ReadData : ExtensibleReadData
     {
         #region Properties
         public ApiCollectionTypeReadData? ApiCollectionType { get; set; }
@@ -69,7 +63,6 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         public ApiNamedTypeReadData? ApiNamedType { get; set; }
         public ApiObjectTypeReadData? ApiObjectType { get; set; }
         public ApiTypeReadData? ApiType { get; set; }
-        public ExtensibleBaseReadData? ExtensibleBase { get; set; }
         #endregion
     }
 
@@ -101,7 +94,8 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
             { propertyNames.ApiType.ClrType, HandleApiTypeClrType },
 
             // ExtensibleBase Property Handlers
-            { propertyNames.ExtensibleBase.Extensions, HandleExtensibleBaseExtensions },
+            { propertyNames.ExtensibleBase.Extensions, (ref Utf8JsonReader reader, ref ReadContext context) =>
+                context.ReadData.Extensions = ReadExtensions(ref reader, context.Options, context.Logger) },
         };
         #endregion
 
@@ -208,14 +202,6 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         }
         #endregion
 
-        #region ExtensibleBase Methods
-        private static void HandleExtensibleBaseExtensions(ref Utf8JsonReader reader, ref ReadContext context)
-        {
-            context.ReadData.ExtensibleBase ??= new ExtensibleBaseReadData();
-
-            context.ReadData.ExtensibleBase.Extensions = ReadExtensions(ref reader, context.Options, context.Logger);
-        }
-        #endregion
     }
     #endregion
 }

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Write.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Write.cs
@@ -10,6 +10,7 @@ using Evoogle.Extension;
 using Evoogle.Json;
 
 using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
+using Evoogle.ApiFramework.Schema.Json.Internal;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
@@ -203,7 +204,7 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
     private static void WriteApiTypeEpilog(Utf8JsonWriter writer, ApiType apiType, WriteContext context)
     {
         WriteApiTypeClrType(writer, apiType, context);
-        WriteExtensibleBaseExtensions(writer, apiType, context);
+        WriteExtensibleBaseExtensions(writer, apiType, context.PropertyNames.ExtensibleBase.Extensions, context.Options, context.Logger);
 
         writer.WriteEndObject();
     }
@@ -224,17 +225,5 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         WriteApiTypeKind(writer, apiType, context);
     }
 
-    // ExtensibleBase Methods
-    private static void WriteExtensibleBaseExtensions(Utf8JsonWriter writer, ExtensibleBase extensibleBase, WriteContext context)
-    {
-        var extensions = extensibleBase.Extensions;
-        if (extensions != null)
-        {
-            var extensionsPropertyName = context.PropertyNames.ExtensibleBase.Extensions;
-            writer.WritePropertyName(extensionsPropertyName);
-
-            WriteExtensions(writer, extensions, context.Options, context.Logger);
-        }
-    }
     #endregion
 }

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/Internal/ApiJsonConverterHelpers.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/Internal/ApiJsonConverterHelpers.cs
@@ -217,6 +217,23 @@ internal static class ApiJsonConverterHelpers
         writer.WriteEndObject();
     }
 
+    public static void WriteExtensibleBaseExtensions<T>
+    (
+        Utf8JsonWriter writer,
+        ExtensibleBase extensibleBase,
+        string propertyName,
+        JsonSerializerOptions options,
+        ILogger<T> logger
+    )
+    {
+        var extensions = extensibleBase.Extensions;
+        if (extensions != null)
+        {
+            writer.WritePropertyName(propertyName);
+            WriteExtensions(writer, extensions, options, logger);
+        }
+    }
+
     public static void AttachExtensions
     (
         ExtensibleBase extensibleBase,

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/Internal/ExtensibleReadData.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/Internal/ExtensibleReadData.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2024-2025 Evoogle.com
+// SPDX-License-Identifier: MIT
+//
+// This file is licensed under the MIT License.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Evoogle.ApiFramework.Schema.Json.Internal;
+
+/// <summary>
+///     Common read data contract for JSON converters that support extensions.
+/// </summary>
+internal class ExtensibleReadData
+{
+    /// <summary>
+    ///     Gets or sets the extensions read from JSON.
+    /// </summary>
+    public Dictionary<string, object>? Extensions { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- introduce ExtensibleReadData to unify extension storage across JSON converters
- move extension writing to ApiJsonConverterHelpers
- use shared extension helpers in all converters to remove duplication

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a103564e2883309a69118aa9bc09bf