### PR TITLE
Add XML documentation for schema support classes

### DIFF
--- a/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ApiSchemaBuilderContext.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Configuration/ApiSchemaBuilderContext.cs
@@ -9,6 +9,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Evoogle.ApiFramework.Schema.Configuration;
 
+/// <summary>
+///     Maintains shared state for <see cref="ApiSchemaBuilder"/> while schema components are being configured.
+///     The context caches builder instances and exposes a consolidated logger to provide consistent diagnostics.
+/// </summary>
+/// <param name="logger">The optional logger used to emit diagnostics during schema construction.</param>
 public sealed class ApiSchemaBuilderContext(ILogger<ApiSchemaBuilder>? logger = null)
 {
     #region Fields

--- a/Source/Evoogle.ApiFramework.Core/Schema/Configuration/Dummy.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Configuration/Dummy.cs
@@ -5,31 +5,66 @@
 // See the LICENSE file in the project root for more information.
 namespace Evoogle.ApiFramework.Schema.Configuration;
 
+/// <summary>
+///     Provides sample domain types and schema configurations that are used in documentation and tests.
+/// </summary>
 public static class Dummy
 {
+    /// <summary>
+    ///     Represents a lightweight value object that wraps a raw email address string.
+    /// </summary>
+    /// <param name="Email">The canonical email address value.</param>
     public record struct EmailAddress(string Email)
     {
+        /// <summary>Implicitly converts a <see cref="string"/> to an <see cref="EmailAddress"/> value object.</summary>
         public static implicit operator EmailAddress(string address) => new(address);
+
+        /// <summary>Implicitly converts an <see cref="EmailAddress"/> value object to its underlying string.</summary>
         public static implicit operator string(EmailAddress emailAddress) => emailAddress.Email;
     }
 
+    /// <summary>
+    ///     Represents a customer domain model that is used by the sample schema builder extensions.
+    /// </summary>
     public class Customer
     {
+        /// <summary>Gets or sets the unique customer identifier.</summary>
         public Guid Id { get; set; }
+
+        /// <summary>Gets or sets the customer's display name.</summary>
         public string Name { get; set; } = string.Empty;
+
+        /// <summary>Gets or sets the optional customer email address.</summary>
         public EmailAddress? Email { get; set; }
+
+        /// <summary>Gets or sets the collection of orders that belong to the customer.</summary>
         public List<Order> Orders { get; set; } = [];
     }
 
+    /// <summary>
+    ///     Represents an order domain model that is used by the sample schema builder extensions.
+    /// </summary>
     public class Order
     {
+        /// <summary>Gets or sets the unique order identifier.</summary>
         public Guid Id { get; set; }
+
+        /// <summary>Gets or sets the current order status.</summary>
         public OrderStatus Status { get; set; }
+
+        /// <summary>Gets or sets the order total.</summary>
         public decimal Total { get; set; }
+
+        /// <summary>Gets or sets the optional identifier of the customer that owns the order.</summary>
         public Guid? CustomerId { get; set; }
+
+        /// <summary>Gets or sets the optional navigation property to the owning customer.</summary>
         public Customer? Customer { get; set; }
     }
 
+    /// <summary>
+    ///     Defines the states that an order can be in for the sample schema configuration.
+    /// </summary>
     public enum OrderStatus
     {
         Pending,
@@ -38,8 +73,12 @@ public static class Dummy
         Cancelled
     }
 
+    /// <summary>
+    ///     Demonstrates how to configure a scalar type using the fluent schema builder APIs.
+    /// </summary>
     public class EmailAddressConfiguration : IApiScalarTypeConfiguration
     {
+        /// <inheritdoc />
         public void Configure(ApiScalarTypeBuilder builder)
         {
             builder
@@ -48,8 +87,12 @@ public static class Dummy
         }
     }
 
+    /// <summary>
+    ///     Demonstrates how to configure an enum type using the fluent schema builder APIs.
+    /// </summary>
     public class OrderStatusConfiguration : IApiEnumTypeConfiguration
     {
+        /// <inheritdoc />
         public void Configure(ApiEnumTypeBuilder builder)
         {
             builder
@@ -62,8 +105,12 @@ public static class Dummy
         }
     }
 
+    /// <summary>
+    ///     Demonstrates how to configure an object type using the fluent schema builder APIs.
+    /// </summary>
     public class OrderConfiguration : IApiObjectTypeConfiguration
     {
+        /// <inheritdoc />
         public void Configure(ApiObjectTypeBuilder builder)
         {
             builder
@@ -75,11 +122,18 @@ public static class Dummy
         }
     }
 
+    /// <summary>
+    ///     Represents a simple extension payload that controls visibility in the sample schema configuration.
+    /// </summary>
     public class VisibleMetadata
     {
+        /// <summary>Gets or sets a value indicating whether the target artifact should be visible.</summary>
         public bool Visible { get; set; }
     }
 
+    /// <summary>
+    ///     Builds a fully configured sample <see cref="ApiSchema"/> demonstrating the fluent builder API surface area.
+    /// </summary>
     public static void DummyMethod()
     {
         var schema = new ApiSchemaBuilder()

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiEnumValueJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiEnumValueJsonConverter.cs
@@ -17,9 +17,16 @@ using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
+/// <summary>
+///     Handles JSON serialization for <see cref="ApiEnumValue"/> instances, including support for extensions.
+/// </summary>
+/// <param name="logger">The optional logger that receives converter diagnostics.</param>
 public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logger) : JsonConverter<ApiEnumValue>
 {
     #region Context Types
+    /// <summary>
+    ///     Represents the shared state required by read and write operations while converting enum values.
+    /// </summary>
     private abstract class Context(ILogger<ApiEnumValueJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames) : IHasLogger<ApiEnumValueJsonConverter>
     {
         #region Immutable Properties
@@ -30,6 +37,9 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         #endregion
     }
 
+    /// <summary>
+    ///     Collects intermediate data while reading an <see cref="ApiEnumValue"/> from JSON.
+    /// </summary>
     private class ReadContext(ILogger<ApiEnumValueJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames, ReadHandlers readHandlers)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -42,6 +52,9 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         #endregion
     }
 
+    /// <summary>
+    ///     Supplies contextual information while writing an <see cref="ApiEnumValue"/> to JSON.
+    /// </summary>
     private class WriteContext(ILogger<ApiEnumValueJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -49,6 +62,9 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
     #endregion
 
     #region Property Types
+    /// <summary>
+    ///     Stores the resolved property names for enum value members under a given naming policy.
+    /// </summary>
     private readonly record struct ApiEnumValuePropertyNames
     {
         #region Immutable Properties
@@ -58,6 +74,9 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         #endregion
     }
 
+    /// <summary>
+    ///     Combines property name metadata used by the converter while reading or writing values.
+    /// </summary>
     private readonly record struct PropertyNames
     {
         #region Immutable Properties
@@ -68,6 +87,9 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
     #endregion
 
     #region Read Types
+    /// <summary>
+    ///     Temporary storage used when deserializing individual enum value members.
+    /// </summary>
     private class ApiEnumValueReadData
     {
         #region Properties
@@ -77,6 +99,9 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         #endregion
     }
 
+    /// <summary>
+    ///     Collects the fully parsed data required to construct an <see cref="ApiEnumValue"/>.
+    /// </summary>
     private class ReadData : ExtensibleReadData
     {
         #region Properties
@@ -84,6 +109,9 @@ public class ApiEnumValueJsonConverter(ILogger<ApiEnumValueJsonConverter>? logge
         #endregion
     }
 
+    /// <summary>
+    ///     Maps JSON property names to handlers that populate <see cref="ReadData"/> during deserialization.
+    /// </summary>
     private class ReadHandlers(PropertyNames propertyNames)
     {
         #region Constants

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiPropertyJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiPropertyJsonConverter.cs
@@ -17,9 +17,16 @@ using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
+/// <summary>
+///     Serializes and deserializes <see cref="ApiProperty"/> instances, including extension payloads and type expressions.
+/// </summary>
+/// <param name="logger">The optional logger used to emit diagnostics during JSON operations.</param>
 public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger) : JsonConverter<ApiProperty>
 {
     #region Context Types
+    /// <summary>
+    ///     Represents the immutable state shared by read and write operations for <see cref="ApiProperty"/> conversion.
+    /// </summary>
     private abstract class Context(ILogger<ApiPropertyJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames) : IHasLogger<ApiPropertyJsonConverter>
     {
         #region Immutable Properties
@@ -30,6 +37,9 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Captures transient state while reading a property from JSON.
+    /// </summary>
     private class ReadContext(ILogger<ApiPropertyJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames, ReadHandlers readHandlers)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -42,6 +52,9 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Provides contextual information required while writing a property to JSON.
+    /// </summary>
     private class WriteContext(ILogger<ApiPropertyJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -49,6 +62,9 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
     #endregion
 
     #region Property Types
+    /// <summary>
+    ///     Stores the resolved JSON property names for an <see cref="ApiProperty"/> under a given naming policy.
+    /// </summary>
     private readonly record struct ApiPropertyPropertyNames
     {
         #region Immutable Properties
@@ -59,6 +75,9 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Bundles the property name metadata used during serialization and deserialization.
+    /// </summary>
     private readonly record struct PropertyNames
     {
         #region Immutable Properties
@@ -69,6 +88,9 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
     #endregion
 
     #region Read Types
+    /// <summary>
+    ///     Temporary storage used while reading property members from JSON.
+    /// </summary>
     private class ApiPropertyReadData
     {
         #region Properties
@@ -79,6 +101,9 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Collects the data required to instantiate an <see cref="ApiProperty"/> during deserialization.
+    /// </summary>
     private class ReadData : ExtensibleReadData
     {
         #region Properties
@@ -86,6 +111,9 @@ public class ApiPropertyJsonConverter(ILogger<ApiPropertyJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Supplies JSON property handlers for mapping serialized values to a <see cref="ReadData"/> instance.
+    /// </summary>
     private class ReadHandlers(PropertyNames propertyNames)
     {
         #region Constants

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiRelationshipJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiRelationshipJsonConverter.cs
@@ -17,9 +17,17 @@ using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
+/// <summary>
+///     Provides System.Text.Json serialization support for <see cref="ApiRelationship"/> instances, including
+///     extension payloads and schema-specific naming policies.
+/// </summary>
+/// <param name="logger">The optional logger used to emit diagnostics while reading or writing relationships.</param>
 public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>? logger) : JsonConverter<ApiRelationship>
 {
     #region Context Types
+    /// <summary>
+    ///     Represents the common state that is required while reading or writing an <see cref="ApiRelationship"/>.
+    /// </summary>
     private abstract class Context(ILogger<ApiRelationshipJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames) : IHasLogger<ApiRelationshipJsonConverter>
     {
         #region Immutable Properties
@@ -30,6 +38,9 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         #endregion
     }
 
+    /// <summary>
+    ///     Captures state that is accumulated while deserializing an <see cref="ApiRelationship"/> from JSON.
+    /// </summary>
     private class ReadContext(ILogger<ApiRelationshipJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames, ReadHandlers readHandlers)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -42,6 +53,9 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         #endregion
     }
 
+    /// <summary>
+    ///     Represents the contextual information required while serializing an <see cref="ApiRelationship"/> to JSON.
+    /// </summary>
     private class WriteContext(ILogger<ApiRelationshipJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -49,6 +63,9 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
     #endregion
 
     #region Property Types
+    /// <summary>
+    ///     Provides cached JSON property names for <see cref="ApiRelationship"/> members under a specific naming policy.
+    /// </summary>
     private readonly record struct ApiRelationshipPropertyNames
     {
         #region Immutable Properties
@@ -57,6 +74,9 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         #endregion
     }
 
+    /// <summary>
+    ///     Aggregates the property name sets used while reading or writing relationships and extension data.
+    /// </summary>
     private readonly record struct PropertyNames
     {
         #region Immutable Properties
@@ -67,6 +87,9 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
     #endregion
 
     #region Read Types
+    /// <summary>
+    ///     Temporary storage used while reading the primitive relationship properties from JSON.
+    /// </summary>
     private class ApiRelationshipReadData
     {
         #region Properties
@@ -75,6 +98,9 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         #endregion
     }
 
+    /// <summary>
+    ///     Collects all data encountered while deserializing a relationship, including extensions.
+    /// </summary>
     private class ReadData : ExtensibleReadData
     {
         #region Properties
@@ -82,6 +108,9 @@ public class ApiRelationshipJsonConverter(ILogger<ApiRelationshipJsonConverter>?
         #endregion
     }
 
+    /// <summary>
+    ///     Provides handlers that map JSON property names to strongly typed relationship data assignments.
+    /// </summary>
     private class ReadHandlers(PropertyNames propertyNames)
     {
         #region Constants

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiSchemaJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiSchemaJsonConverter.cs
@@ -68,6 +68,9 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
     #endregion
 
     #region Property Types
+    /// <summary>
+    ///     Represents the JSON property names associated with an <see cref="ApiSchema"/> for a given naming policy.
+    /// </summary>
     private readonly record struct ApiSchemaPropertyNames
     {
         #region Immutable Properties
@@ -79,6 +82,9 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
         #endregion
     }
 
+    /// <summary>
+    ///     Aggregates all property name metadata used during schema serialization and deserialization.
+    /// </summary>
     private readonly record struct PropertyNames
     {
         #region Immutable Properties
@@ -89,6 +95,9 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
     #endregion
 
     #region Read Types
+    /// <summary>
+    ///     Temporary storage used while parsing an <see cref="ApiSchema"/> from JSON.
+    /// </summary>
     private class ApiSchemaReadData
     {
         #region Properties
@@ -100,6 +109,9 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
         #endregion
     }
 
+    /// <summary>
+    ///     Collects the complete data set required to instantiate an <see cref="ApiSchema"/> during deserialization.
+    /// </summary>
     private class ReadData : ExtensibleReadData
     {
         #region Properties
@@ -107,6 +119,9 @@ public class ApiSchemaJsonConverter(ILogger<ApiSchemaJsonConverter>? logger) : J
         #endregion
     }
 
+    /// <summary>
+    ///     Provides property handlers that map JSON members to <see cref="ReadData"/> assignments.
+    /// </summary>
     private class ReadHandlers(PropertyNames propertyNames)
     {
         #region ApiSchema Fields

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeExpressionJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeExpressionJsonConverter.cs
@@ -16,9 +16,16 @@ using static Evoogle.ApiFramework.Schema.Json.Internal.ApiJsonConverterHelpers;
 
 namespace Evoogle.ApiFramework.Schema.Json;
 
+/// <summary>
+///     Converts <see cref="ApiTypeExpression"/> instances to and from JSON, including inline types and references.
+/// </summary>
+/// <param name="logger">The optional logger that receives diagnostics for serialization operations.</param>
 public class ApiTypeExpressionJsonConverter(ILogger<ApiTypeExpressionJsonConverter>? logger) : JsonConverter<ApiTypeExpression>
 {
     #region Context Types
+    /// <summary>
+    ///     Encapsulates the immutable state needed while reading or writing type expressions.
+    /// </summary>
     private abstract class Context(ILogger<ApiTypeExpressionJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames) : IHasLogger<ApiTypeExpressionJsonConverter>
     {
         #region Immutable Properties
@@ -29,6 +36,9 @@ public class ApiTypeExpressionJsonConverter(ILogger<ApiTypeExpressionJsonConvert
         #endregion
     }
 
+    /// <summary>
+    ///     Holds intermediate values while deserializing an <see cref="ApiTypeExpression"/> from JSON.
+    /// </summary>
     private class ReadContext(ILogger<ApiTypeExpressionJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames, ReadHandlers readHandlers)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -41,6 +51,9 @@ public class ApiTypeExpressionJsonConverter(ILogger<ApiTypeExpressionJsonConvert
         #endregion
     }
 
+    /// <summary>
+    ///     Provides converter state while writing an <see cref="ApiTypeExpression"/> to JSON.
+    /// </summary>
     private class WriteContext(ILogger<ApiTypeExpressionJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -48,6 +61,9 @@ public class ApiTypeExpressionJsonConverter(ILogger<ApiTypeExpressionJsonConvert
     #endregion
 
     #region Property Types
+    /// <summary>
+    ///     Caches the JSON property names used to represent a type expression for the active naming policy.
+    /// </summary>
     private readonly record struct ApiTypeExpressionPropertyNames
     {
         #region Immutable Properties
@@ -58,6 +74,9 @@ public class ApiTypeExpressionJsonConverter(ILogger<ApiTypeExpressionJsonConvert
         #endregion
     }
 
+    /// <summary>
+    ///     Aggregates all property names used by the converter for a given naming policy.
+    /// </summary>
     private readonly record struct PropertyNames
     {
         #region Immutable Properties
@@ -67,6 +86,9 @@ public class ApiTypeExpressionJsonConverter(ILogger<ApiTypeExpressionJsonConvert
     #endregion
 
     #region Read Types
+    /// <summary>
+    ///     Temporary storage that holds parsed values prior to creating an <see cref="ApiTypeExpression"/>.
+    /// </summary>
     private class ApiTypeExpressionReadData
     {
         #region Properties
@@ -77,6 +99,9 @@ public class ApiTypeExpressionJsonConverter(ILogger<ApiTypeExpressionJsonConvert
         #endregion
     }
 
+    /// <summary>
+    ///     Captures the overall data read from JSON for a single type expression instance.
+    /// </summary>
     private class ReadData
     {
         #region Properties
@@ -84,6 +109,9 @@ public class ApiTypeExpressionJsonConverter(ILogger<ApiTypeExpressionJsonConvert
         #endregion
     }
 
+    /// <summary>
+    ///     Provides JSON property handlers that populate <see cref="ReadData"/> during deserialization.
+    /// </summary>
     private class ReadHandlers(PropertyNames propertyNames)
     {
         #region ApiTypeExpression Fields

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Read.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.Read.cs
@@ -16,6 +16,9 @@ namespace Evoogle.ApiFramework.Schema.Json;
 public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
 {
     #region Read Types
+    /// <summary>
+    ///     Holds interim data for <see cref="ApiCollectionType"/> members encountered during deserialization.
+    /// </summary>
     private class ApiCollectionTypeReadData
     {
         #region Properties
@@ -24,6 +27,9 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
     }
 
+    /// <summary>
+    ///     Holds interim data for <see cref="ApiEnumType"/> members encountered during deserialization.
+    /// </summary>
     private class ApiEnumTypeReadData
     {
         #region Properties
@@ -31,6 +37,9 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
     }
 
+    /// <summary>
+    ///     Holds interim data for <see cref="ApiNamedType"/> members encountered during deserialization.
+    /// </summary>
     private class ApiNamedTypeReadData
     {
         #region Properties
@@ -38,6 +47,9 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
     }
 
+    /// <summary>
+    ///     Holds interim data for <see cref="ApiObjectType"/> members encountered during deserialization.
+    /// </summary>
     private class ApiObjectTypeReadData
     {
         #region Properties
@@ -46,6 +58,9 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
     }
 
+    /// <summary>
+    ///     Holds interim data for common <see cref="ApiType"/> members encountered during deserialization.
+    /// </summary>
     private class ApiTypeReadData
     {
         #region Properties
@@ -54,6 +69,9 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
     }
 
+    /// <summary>
+    ///     Aggregates all temporary data required to create an <see cref="ApiType"/> instance from JSON.
+    /// </summary>
     private class ReadData : ExtensibleReadData
     {
         #region Properties
@@ -65,6 +83,9 @@ public partial class ApiTypeJsonConverter : JsonConverter<ApiType>
         #endregion
     }
 
+    /// <summary>
+    ///     Provides JSON property handlers that map serialized data to <see cref="ReadData"/> during deserialization.
+    /// </summary>
     private class ReadHandlers(PropertyNames propertyNames)
     {
         #region Constants

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/ApiTypeJsonConverter.cs
@@ -28,6 +28,9 @@ namespace Evoogle.ApiFramework.Schema.Json;
 public partial class ApiTypeJsonConverter(ILogger<ApiTypeJsonConverter>? logger) : JsonConverter<ApiType>
 {
     #region Context Types
+    /// <summary>
+    ///     Encapsulates the immutable state required while reading or writing <see cref="ApiType"/> instances.
+    /// </summary>
     private abstract class Context(ILogger<ApiTypeJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames) : IHasLogger<ApiTypeJsonConverter>
     {
         #region Immutable Properties
@@ -38,6 +41,9 @@ public partial class ApiTypeJsonConverter(ILogger<ApiTypeJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Captures intermediate state while deserializing a polymorphic <see cref="ApiType"/>.
+    /// </summary>
     private class ReadContext(ILogger<ApiTypeJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames, ReadHandlers readHandlers)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -51,6 +57,9 @@ public partial class ApiTypeJsonConverter(ILogger<ApiTypeJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Provides converter state while serializing a concrete <see cref="ApiType"/> instance.
+    /// </summary>
     private class WriteContext(ILogger<ApiTypeJsonConverter> logger, JsonSerializerOptions options, JsonNamingPolicy propertyNamingPolicy, PropertyNames propertyNames)
         : Context(logger, options, propertyNamingPolicy, propertyNames)
     {
@@ -58,6 +67,9 @@ public partial class ApiTypeJsonConverter(ILogger<ApiTypeJsonConverter>? logger)
     #endregion
 
     #region Property Types
+    /// <summary>
+    ///     Stores the JSON member names for <see cref="ApiCollectionType"/> properties under the active naming policy.
+    /// </summary>
     private readonly record struct ApiCollectionTypePropertyNames
     {
         #region Immutable Properties
@@ -66,6 +78,9 @@ public partial class ApiTypeJsonConverter(ILogger<ApiTypeJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Stores the JSON member names for <see cref="ApiEnumType"/> properties under the active naming policy.
+    /// </summary>
     private readonly record struct ApiEnumTypePropertyNames
     {
         #region Immutable Properties
@@ -73,12 +88,19 @@ public partial class ApiTypeJsonConverter(ILogger<ApiTypeJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Stores the JSON member names for <see cref="ApiNamedType"/> properties under the active naming policy.
+    /// </summary>
     private readonly record struct ApiNamedTypePropertyNames
     {
         #region Immutable Properties
         public required string ApiName { get; init; }
         #endregion
     }
+
+    /// <summary>
+    ///     Stores the JSON member names for <see cref="ApiObjectType"/> properties under the active naming policy.
+    /// </summary>
     private readonly record struct ApiObjectTypePropertyNames
     {
         #region Immutable Properties
@@ -87,6 +109,9 @@ public partial class ApiTypeJsonConverter(ILogger<ApiTypeJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Stores the JSON member names for base <see cref="ApiType"/> properties under the active naming policy.
+    /// </summary>
     private readonly record struct ApiTypePropertyNames
     {
         #region Immutable Properties
@@ -95,6 +120,9 @@ public partial class ApiTypeJsonConverter(ILogger<ApiTypeJsonConverter>? logger)
         #endregion
     }
 
+    /// <summary>
+    ///     Aggregates all property name groups used by the converter for a given naming policy.
+    /// </summary>
     private readonly record struct PropertyNames
     {
         #region Immutable Properties

--- a/Source/Evoogle.ApiFramework.Core/Schema/Json/Internal/ApiJsonConverterHelpers.cs
+++ b/Source/Evoogle.ApiFramework.Core/Schema/Json/Internal/ApiJsonConverterHelpers.cs
@@ -24,6 +24,9 @@ internal static class ApiJsonConverterHelpers
     #region Types
     public delegate void ApiJsonReaderHandler<TContext>(ref Utf8JsonReader reader, ref TContext context);
 
+    /// <summary>
+    ///     Represents the JSON property names required to materialize <see cref="ExtensibleBase"/> instances.
+    /// </summary>
     public readonly record struct ExtensibleBasePropertyNames
     {
         #region Properties
@@ -31,6 +34,9 @@ internal static class ApiJsonConverterHelpers
         #endregion
     }
 
+    /// <summary>
+    ///     Serves as a base type for read-data structures that need to capture extension payloads.
+    /// </summary>
     public class ExtensibleReadData
     {
         #region Properties


### PR DESCRIPTION
## Summary
- document the sample configuration types and builder context with XML comments
- expand XML documentation across JSON converters and helper types for schema serialization

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d71c335e848330b9ce89d60eb15a74